### PR TITLE
[release-4.14] OCPBUGS-15313: Bump word-wrap package to 1.2.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,5 +84,7 @@
     "webpack": "^5.68.0",
     "@types/react": "17.0.40"
   },
-  "dependencies": {}
+  "dependencies": {
+    "word-wrap": "^1.2.5"
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8270,6 +8270,11 @@ word-wrap@^1.2.3, word-wrap@~1.2.3:
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"
   integrity sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==
 
+word-wrap@^1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.5.tgz#d2c45c6dd4fbce621a66f136cbe328afd0410b34"
+  integrity sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==
+
 wrap-ansi@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-2.1.0.tgz#d8fc3d284dd05794fe84973caecdd1cf824fdd85"


### PR DESCRIPTION
Manual cherry-pick of a single commit from #29 