### PR TITLE
install yarn from npm if not found in cache

### DIFF
--- a/Dockerfile.art
+++ b/Dockerfile.art
@@ -13,8 +13,7 @@ RUN CACHED_YARN=./artifacts/yarn-${YARN_VERSION}.tar.gz; \
     if [ -f ${CACHED_YARN} ]; then \
       npm install -g ${CACHED_YARN}; \
     else \
-      echo "need yarn at ${CACHED_YARN}"; \
-      exit 1; \
+      npm install https://github.com/yarnpkg/yarn/releases/download/${YARN_VERSION}/yarn-${YARN_VERSION}.tar.gz; \
     fi
 
 # use dependencies provided by Cachito


### PR DESCRIPTION
Konflux builds were erroring out since cached yarn was empty.

 Following same pattern as openshift/console: https://github.com/openshift/console/blob/7acaf06571919e77b997f85bf1e90aa01e46b6f9/Dockerfile#L27C7-L27C115 we can install yarn using npm.