### PR TITLE
Order nodes by interface type

### DIFF
--- a/src/views/states/topology/Topology.tsx
+++ b/src/views/states/topology/Topology.tsx
@@ -98,10 +98,12 @@ const Topology: FC = () => {
             controlButtons={createTopologyControlButtons({
               ...defaultControlButtonsOptions,
               zoomInCallback: action(() => {
-                visualization.getGraph().scaleBy(4 / 3);
+                const scale = visualization.getGraph().getScale();
+                visualization.getGraph().setScale(scale * 1.1);
               }),
               zoomOutCallback: action(() => {
-                visualization.getGraph().scaleBy(0.75);
+                const scale = visualization.getGraph().getScale();
+                visualization.getGraph().setScale(scale * 0.9);
               }),
               fitToScreenCallback: action(() => {
                 visualization.getGraph().fit(40);

--- a/src/views/states/topology/utils/LevelsLayout.ts
+++ b/src/views/states/topology/utils/LevelsLayout.ts
@@ -1,0 +1,209 @@
+import {
+  BaseLayout,
+  Edge,
+  Graph,
+  GRAPH_LAYOUT_END_EVENT,
+  GridLayoutOptions,
+  Layout,
+  LayoutLink,
+  LayoutNode,
+  Node,
+} from '@patternfly/react-topology';
+import { GridGroup } from '@patternfly/react-topology/dist/esm/layouts/GridGroup';
+import { GridLink } from '@patternfly/react-topology/dist/esm/layouts/GridLink';
+import { GridNode } from '@patternfly/react-topology/dist/esm/layouts/GridNode';
+
+export class LevelsLayout extends BaseLayout implements Layout {
+  constructor(graph: Graph, options?: Partial<GridLayoutOptions>) {
+    super(graph, options);
+  }
+
+  // Method to sort nodes by their level
+  private sortNodesByLevel(nodes: LayoutNode[]): LayoutNode[] {
+    return nodes.sort((a, b) => {
+      const aLevel = a?.element?.getData()?.level;
+      const bLevel = b?.element?.getData()?.level;
+      return aLevel - bLevel;
+    });
+  }
+
+  // Method to count nodes per level
+  private countNodesPerLevel(nodes: LayoutNode[]): { [level: number]: number } {
+    const levelCounts: { [level: number]: number } = {};
+    nodes.forEach((node) => {
+      const level = node?.element?.getData()?.level;
+      if (!levelCounts[level]) {
+        levelCounts[level] = 0;
+      }
+      levelCounts[level]++;
+    });
+    return levelCounts;
+  }
+
+  // Method to create a layout node
+  protected createLayoutNode(node: Node, nodeDistance: number, index: number) {
+    return new GridNode(node, nodeDistance, index);
+  }
+
+  // Method to create a layout link
+  protected createLayoutLink(
+    edge: Edge,
+    source: LayoutNode,
+    target: LayoutNode,
+    isFalse: boolean,
+  ): LayoutLink {
+    return new GridLink(edge, source, target, isFalse);
+  }
+
+  // Method to create a layout group
+  protected createLayoutGroup(node: Node, padding: number, index: number) {
+    return new GridGroup(node, padding, index);
+  }
+
+  // Method to determine maximum node dimensions
+  private getMaxNodeDimensions(groupNodes: LayoutNode[]): { padX: number; padY: number } {
+    let padX = 0;
+    let padY = 0;
+
+    groupNodes.forEach((node) => {
+      if (padX < node.width) {
+        padX = node.width;
+      }
+      if (padY < node.height) {
+        padY = node.height;
+      }
+    });
+
+    return { padX, padY };
+  }
+
+  // Method to layout nodes by level
+  private layoutNodesByLevel(
+    sortedNodes: LayoutNode[],
+    offsetX: number,
+    offsetY: number,
+    padX: number,
+    padY: number,
+  ): { maxX: number; maxY: number } {
+    const levelCounts = this.countNodesPerLevel(sortedNodes);
+    let currentLevel = sortedNodes[0]?.element?.getData()?.level;
+    let nodesInCurrentLevel = 0;
+
+    let x = offsetX;
+    let y = offsetY;
+    let maxX = x;
+    let maxY = y;
+
+    sortedNodes.forEach((node) => {
+      if (node?.element?.getData()?.level !== currentLevel) {
+        // Move to the next level when the level changes
+        currentLevel = node?.element?.getData()?.level;
+        x = offsetX;
+        y += padY + 20; // Adding some extra space between levels
+        nodesInCurrentLevel = 0;
+      }
+
+      node.x = x;
+      node.y = y;
+      node.update();
+
+      nodesInCurrentLevel++;
+      const numNodesInRow = levelCounts[currentLevel];
+
+      if (nodesInCurrentLevel < numNodesInRow) {
+        x += padX + 20; // Adding some extra space between nodes
+      } else {
+        x = offsetX;
+        y += padY + 20; // Move to the next row within the same level
+        nodesInCurrentLevel = 0;
+      }
+
+      // Track maxX and maxY to determine the total space used by this group
+      if (x > maxX) maxX = x;
+      if (y > maxY) maxY = y;
+    });
+
+    return { maxX, maxY };
+  }
+
+  // Method to layout nodes within a group
+  private positionGroupNodes(
+    groupNodes: LayoutNode[],
+    offsetX: number,
+    offsetY: number,
+  ): { width: number; height: number } {
+    const sortedNodes = this.sortNodesByLevel(groupNodes);
+    const { padX, padY } = this.getMaxNodeDimensions(sortedNodes);
+    const { maxX, maxY } = this.layoutNodesByLevel(sortedNodes, offsetX, offsetY, padX, padY);
+
+    // Return the dimensions of the group layout
+    return { width: maxX - offsetX + padX, height: maxY - offsetY + padY };
+  }
+
+  // Method to group nodes by their parent group
+  private groupNodesByParent(): { [groupId: string]: LayoutNode[] } {
+    const groups: { [groupId: string]: LayoutNode[] } = {};
+    this.nodes.forEach((node) => {
+      const parentGroupId = node.element.getParent()?.getId();
+      if (parentGroupId) {
+        if (!groups[parentGroupId]) {
+          groups[parentGroupId] = [];
+        }
+        groups[parentGroupId].push(node);
+      }
+    });
+    return groups;
+  }
+
+  // Method to calculate maximum group dimensions
+  private calculateMaxGroupDimensions(groups: { [groupId: string]: LayoutNode[] }): {
+    maxGroupWidth: number;
+    maxGroupHeight: number;
+  } {
+    const groupDimensions = Object.keys(groups).map((key) =>
+      this.positionGroupNodes(groups[key], 0, 0),
+    );
+    const maxGroupWidth = Math.max(...groupDimensions.map((dim) => dim.width));
+    const maxGroupHeight = Math.max(...groupDimensions.map((dim) => dim.height));
+    return { maxGroupWidth, maxGroupHeight };
+  }
+
+  // Method to position groups in a grid layout
+  private positionGroupsInGrid(
+    groups: { [groupId: string]: LayoutNode[] },
+    maxGroupWidth: number,
+    maxGroupHeight: number,
+  ): void {
+    const groupKeys = Object.keys(groups);
+    const totalGroups = groupKeys.length;
+    const numCols = Math.ceil(Math.sqrt(totalGroups));
+
+    let offsetX = 0;
+    let offsetY = 0;
+
+    for (let row = 0; row < Math.ceil(totalGroups / numCols); row++) {
+      for (let col = 0; col < numCols; col++) {
+        const groupIndex = row * numCols + col;
+        if (groupIndex < totalGroups) {
+          const groupNodes = groups[groupKeys[groupIndex]];
+          this.positionGroupNodes(groupNodes, offsetX, offsetY);
+          offsetX += maxGroupWidth + 50; // Adding some extra space between groups
+        }
+      }
+      offsetX = 0;
+      offsetY += maxGroupHeight + 50; // Adding some extra space between rows of groups
+    }
+  }
+
+  // Main layout method
+  protected startLayout(graph: Graph, initialRun: boolean, addingNodes: boolean): void {
+    if (initialRun || addingNodes) {
+      this.nodes.sort((a, b) => a.id.localeCompare(b.id));
+      const groups = this.groupNodesByParent();
+      const { maxGroupWidth, maxGroupHeight } = this.calculateMaxGroupDimensions(groups);
+      this.positionGroupsInGrid(groups, maxGroupWidth, maxGroupHeight);
+    }
+
+    this.graph.getController().fireEvent(GRAPH_LAYOUT_END_EVENT, { graph: this.graph });
+  }
+}

--- a/src/views/states/topology/utils/factory.ts
+++ b/src/views/states/topology/utils/factory.ts
@@ -1,11 +1,7 @@
 import {
-  ColaLayout,
   ComponentFactory,
   DefaultEdge,
-  Graph,
   GraphComponent,
-  Layout,
-  LayoutFactory,
   ModelKind,
   nodeDragSourceSpec,
   withDragNode,
@@ -17,9 +13,11 @@ import CustomGroup from '../components/CustomGroup/CustomGroup';
 import CustomNode from '../components/CustomNode/CustomNode';
 
 import { GROUP } from './constants';
+import { LevelsLayout } from './LevelsLayout';
 
-export const layoutFactory: LayoutFactory = (type: string, graph: Graph): Layout | undefined =>
-  new ColaLayout(graph, { layoutOnDrag: false });
+export const layoutFactory = (type, graph) => {
+  return new LevelsLayout(graph, { layoutOnDrag: true });
+};
 
 export const componentFactory: ComponentFactory = (kind: ModelKind, type: string) => {
   switch (type) {

--- a/src/views/states/topology/utils/utils.ts
+++ b/src/views/states/topology/utils/utils.ts
@@ -20,6 +20,19 @@ const statusMap: { [key: string]: NodeStatus } = {
   absent: NodeStatus.warning,
 };
 
+const networkTypeLevelMap = {
+  [InterfaceType.ETHERNET]: 1,
+  [InterfaceType.BOND]: 2,
+  [InterfaceType.VLAN]: 3,
+  [InterfaceType.LINUX_BRIDGE]: 4,
+};
+
+export const networkNodeLevel = new Proxy(networkTypeLevelMap, {
+  get(target, prop: string) {
+    return target[prop] ?? 5;
+  },
+});
+
 const getStatus = (iface: NodeNetworkConfigurationInterface): NodeStatus => {
   return statusMap[iface.state.toLowerCase()] || NodeStatus.default;
 };
@@ -55,6 +68,7 @@ const createNodes = (
       bridgePorts: iface.bridge?.port,
       bondPorts: iface['link-aggregation']?.port,
       vlanBaseInterface: iface.vlan?.['base-iface'],
+      level: networkNodeLevel[iface.type],
     },
     parent: nnsName,
   }));
@@ -172,7 +186,7 @@ export const transformDataToTopologyModel = (
     graph: {
       id: 'nns-topology',
       type: ModelKind.graph,
-      layout: 'Cola',
+      layout: 'Levels',
     },
   };
 };


### PR DESCRIPTION
Creating a new topology layout to have different levels for each type of interface in each node

Before: Randomly rendered, random layout
![topology-b4](https://github.com/user-attachments/assets/384422fc-7224-4cd6-8eaa-bdac9d58327c)

After: (QE cluster with 6 nodes)
![topology-sorted-fit-all-screen2](https://github.com/user-attachments/assets/3596c84c-2307-4225-8fe5-61a36b5214e3)
![topology-sorted-zoomed2](https://github.com/user-attachments/assets/75f7d0e6-89c1-4492-910f-2b97782d5cc7)

CNV engineering cluster: (24 nodes)
![topology-sorted-zoomed](https://github.com/user-attachments/assets/2db926e1-da19-4beb-a6b5-cc1648984f4b)
![topology-sorted-fit-all-screen](https://github.com/user-attachments/assets/81ea2036-b640-42c3-a2ec-9a227dbec448)
