### PR TITLE
CNV-41967: display nncp configred interfaces

### DIFF
--- a/src/views/states/topology/components/CustomNode/CustomNode.scss
+++ b/src/views/states/topology/components/CustomNode/CustomNode.scss
@@ -1,4 +1,10 @@
 .custom-node {
+  position: relative;
+
+  &__inner-border {
+    pointer-events: none;
+  }
+
   .pf-topology__node__background {
     stroke-width: 4px;
   }

--- a/src/views/states/topology/components/CustomNode/CustomNode.tsx
+++ b/src/views/states/topology/components/CustomNode/CustomNode.tsx
@@ -25,11 +25,27 @@ const CustomNode: FC<CustomNodeProps> = ({ element, ...rest }) => {
 
   const xCenter = (width - ICON_SIZE) / 2;
   const yCenter = (height - ICON_SIZE) / 2;
+
+  const isDerivedFromPolicy = data.isDerivedFromPolicy;
   return (
     <DefaultNode className="custom-node" element={element} truncateLength={8} {...rest}>
       <g transform={`translate(${xCenter}, ${yCenter})`}>
         <Icon width={ICON_SIZE} height={ICON_SIZE} />
       </g>
+      {isDerivedFromPolicy && (
+        <rect
+          className="custom-node__inner-border"
+          x={8}
+          y={8}
+          width={width - 16}
+          height={height - 16}
+          rx="50%"
+          ry="50%"
+          stroke="#007BFF"
+          strokeWidth={2}
+          fill="none"
+        />
+      )}
     </DefaultNode>
   );
 };


### PR DESCRIPTION
NodeNetworkState interfaces can be added/deleted/updated by NodeNetworkConfigurationPolicy: https://nmstate.io/kubernetes-nmstate/user-guide/102-configuration.html

Displaying NNCP configured interfaces by making their nodes circle shaped with a blue inner circle (inner in oppose to the status border each interface might have.)

After:
 
![topology-add-nnce-interfaces2](https://github.com/user-attachments/assets/69fadf95-9e8a-4399-a7f9-2aa030d05914)
![topology-add-nnce-interfaces](https://github.com/user-attachments/assets/4706d067-2a83-4805-859a-c231e7cd019a)
