### PR TITLE
Add missing YAML tab for selected interface

### DIFF
--- a/src/views/states/topology/components/TopologySidebar/TopologySidebar.tsx
+++ b/src/views/states/topology/components/TopologySidebar/TopologySidebar.tsx
@@ -1,11 +1,10 @@
 import React, { Dispatch, FC, SetStateAction, useMemo } from 'react';
 
-import { Divider, Title } from '@patternfly/react-core';
 import { TopologySideBar } from '@patternfly/react-topology';
 import { V1beta1NodeNetworkState } from '@types';
 
 import StateDetailsPage from '../../../details/StateDetailsPage';
-import InterfaceDrawerDetailsTab from '../../../list/components/InterfaceDrawer/InterfaceDrawerDetailsTab';
+import InterfaceDrawer from '../../../list/components/InterfaceDrawer/InterfaceDrawer';
 
 import './TopologySidebar.scss';
 
@@ -34,9 +33,10 @@ const TopologySidebar: FC<TopologySidebarProps> = ({ states, selectedIds, setSel
           <StateDetailsPage nns={selectedState} />
         ) : (
           <>
-            <Title headingLevel="h2">{selectedInterface?.name}</Title>
-            <Divider style={{ padding: '1rem 0' }} />
-            <InterfaceDrawerDetailsTab selectedInterface={selectedInterface} />
+            <InterfaceDrawer
+              selectedInterface={selectedInterface}
+              onClose={() => setSelectedIds([])}
+            />
           </>
         )}
       </div>

--- a/src/views/states/topology/utils/utils.ts
+++ b/src/views/states/topology/utils/utils.ts
@@ -26,15 +26,15 @@ const statusMap: { [key: string]: NodeStatus } = {
 };
 
 const networkTypeLevelMap = {
-  [InterfaceType.LINUX_BRIDGE]: 1,
-  [InterfaceType.VLAN]: 2,
-  [InterfaceType.BOND]: 3,
-  [InterfaceType.ETHERNET]: 4,
+  [InterfaceType.LINUX_BRIDGE]: 2,
+  [InterfaceType.VLAN]: 3,
+  [InterfaceType.BOND]: 4,
+  [InterfaceType.ETHERNET]: 5,
 };
 
 export const networkNodeLevel = new Proxy(networkTypeLevelMap, {
   get(target, prop: string) {
-    return target[prop] ?? 5;
+    return target[prop] ?? 1;
   },
 });
 


### PR DESCRIPTION
Adding a YAML tab for selected interface on the topology view, also fixed order so ethernet would be at the bottom, above it bond than vlans than bridges and everything else.
