### PR TITLE
Fix tests

### DIFF
--- a/cypress/support/selectors.ts
+++ b/cypress/support/selectors.ts
@@ -3,5 +3,4 @@ export const EXPAND_INTERFACE_INFO = 'ethernet-expandable-section-toggle';
 export const INTERFACE_DRAWER_TEST_ID = 'interface-drawer';
 export const LLDP_DRAWER_DETAILS_SECTION_TEST_ID = 'lldp-section';
 
-export const SEARCH_FILTER_DROPDOWN =
-  'button.pf-v5-c-dropdown__toggle[data-test-id="dropdown-button"]';
+export const SEARCH_FILTER_DROPDOWN = 'button[data-test-id="dropdown-button"]';


### PR DESCRIPTION
pf6 console broke tests as we use a too specific selector

https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/openshift_nmstate-console-plugin/86/pull-ci-openshift-nmstate-console-plugin-main-e2e-tests/1891960094950690816/artifacts/e2e-tests/e2e-tests/artifacts/screenshots/StatusList.spec.cy.ts/NodeNetworkState%20list%20--%20search%20by%20lldp%20system%20name%20(failed).png