### PR TITLE
CNV-55191: create policy drawer

### DIFF
--- a/plugin-manifest.ts
+++ b/plugin-manifest.ts
@@ -2,6 +2,10 @@ import type { EncodedExtension } from '@openshift/dynamic-plugin-sdk';
 import { FeatureFlag } from '@openshift-console/dynamic-plugin-sdk';
 import type { ConsolePluginBuildMetadata } from '@openshift-console/dynamic-plugin-sdk-webpack';
 
+import {
+  HostNetworkConfigurationExtensions,
+  HostNetworkConfigurationModules,
+} from './src/views/hostnetworkconfiguration/manifest';
 import { PolicyExposedModules, PolicyExtensions } from './src/views/policies/manifest';
 import { StateExposedModules, StateExtensions } from './src/views/states/manifest';
 
@@ -14,6 +18,7 @@ export const pluginMetadata: ConsolePluginBuildMetadata = {
   exposedModules: {
     ...PolicyExposedModules,
     ...StateExposedModules,
+    ...HostNetworkConfigurationModules,
     nmstateFlags: './utils/flags',
   },
   dependencies: {
@@ -30,4 +35,5 @@ export const extensions: EncodedExtension[] = [
   } as EncodedExtension<FeatureFlag>,
   ...PolicyExtensions,
   ...StateExtensions,
+  ...HostNetworkConfigurationExtensions,
 ];

--- a/src/utils/components/PolicyForm/PolicyWizard/BasicInfoStep.tsx
+++ b/src/utils/components/PolicyForm/PolicyWizard/BasicInfoStep.tsx
@@ -1,0 +1,91 @@
+import React, { FC, useState } from 'react';
+import { Trans } from 'react-i18next';
+import { useNMStateTranslation } from 'src/utils/hooks/useNMStateTranslation';
+import { Updater } from 'use-immer';
+
+import { Content, Form, FormGroup, TextInput, Title } from '@patternfly/react-core';
+import { V1NodeNetworkConfigurationPolicy } from '@types';
+import NodeSelectorModal from '@utils/components/NodeSelectorModal/NodeSelectorModal';
+
+import ApplySelectorCheckbox from '../ApplySelectorCheckbox';
+
+type InfoStepProps = {
+  policy: V1NodeNetworkConfigurationPolicy;
+  setPolicy: Updater<V1NodeNetworkConfigurationPolicy>;
+};
+
+const BasicInfoStep: FC<InfoStepProps> = ({ setPolicy, policy }) => {
+  const { t } = useNMStateTranslation();
+  const [modalOpen, setModalOpen] = useState(false);
+
+  const onDescriptionChange = (newDescription: string) => {
+    setPolicy(({ metadata }) => {
+      if (!metadata.annotations) metadata.annotations = {};
+
+      metadata.annotations.description = newDescription;
+    });
+  };
+  return (
+    <Form>
+      <Title headingLevel="h3">{t('General')}</Title>
+      <>
+        <NodeSelectorModal
+          isOpen={modalOpen}
+          policy={policy}
+          onClose={() => setModalOpen(false)}
+          onSubmit={(newPolicy) => {
+            setPolicy(newPolicy);
+            setModalOpen(false);
+          }}
+        />
+        <FormGroup fieldId="text">
+          <Content component="p">
+            <Trans t={t} ns="plugin__nmstate-console-plugin">
+              Node network is configured and managed by NM state. Create a node network
+              configuration policy to describe the requested network configuration on your nodes in
+              the cluster. The node network configuration enactment reports the netwrok policies
+              enacted upon each node.
+            </Trans>
+          </Content>
+        </FormGroup>
+        <FormGroup fieldId="apply-selector">
+          <ApplySelectorCheckbox
+            isChecked={!!policy?.spec.nodeSelector}
+            onChange={(_, checked) => {
+              if (checked) return setModalOpen(true);
+
+              setPolicy((draftPolicy) => {
+                delete draftPolicy.spec.nodeSelector;
+              });
+            }}
+          />
+        </FormGroup>
+      </>
+      <FormGroup label={t('Policy name')} isRequired fieldId="policy-name-group">
+        <TextInput
+          isRequired
+          type="text"
+          id="policy-name"
+          name="policy-name"
+          value={policy?.metadata?.name}
+          onChange={(_, newName) =>
+            setPolicy((draftPolicy) => {
+              draftPolicy.metadata.name = newName;
+            })
+          }
+        />
+      </FormGroup>
+      <FormGroup label={t('Description')} fieldId="policy-description-group">
+        <TextInput
+          type="text"
+          id="policy-description"
+          name="policy-description"
+          value={policy?.metadata?.annotations?.description}
+          onChange={(_, newValue) => onDescriptionChange(newValue)}
+        />
+      </FormGroup>
+    </Form>
+  );
+};
+
+export default BasicInfoStep;

--- a/src/utils/components/PolicyForm/PolicyWizard/InterfacesStep.tsx
+++ b/src/utils/components/PolicyForm/PolicyWizard/InterfacesStep.tsx
@@ -1,0 +1,102 @@
+import React, { FC } from 'react';
+import { Updater } from 'use-immer';
+
+import {
+  Alert,
+  AlertVariant,
+  Button,
+  ButtonVariant,
+  Content,
+  Form,
+  Popover,
+  Title,
+} from '@patternfly/react-core';
+import { HelpIcon, PlusCircleIcon } from '@patternfly/react-icons';
+import {
+  InterfaceType,
+  NodeNetworkConfigurationInterface,
+  V1NodeNetworkConfigurationPolicy,
+} from '@types';
+import { useNMStateTranslation } from '@utils/hooks/useNMStateTranslation';
+
+import PolicyFormOVSBridgeMapping from '../PolicyFormOVSBridgeMapping';
+import PolicyInterfacesExpandable from '../PolicyInterfaceExpandable';
+import { isOVSBridgeExisting } from '../utils';
+
+type InterfacesStepProps = {
+  policy: V1NodeNetworkConfigurationPolicy;
+  setPolicy: Updater<V1NodeNetworkConfigurationPolicy>;
+  error?: Error;
+};
+
+const InterfacesStep: FC<InterfacesStepProps> = ({ policy, setPolicy, error }) => {
+  const { t } = useNMStateTranslation();
+
+  const addNewInterface = () => {
+    setPolicy((draftPolicy) => {
+      if (!draftPolicy.spec?.desiredState?.interfaces) {
+        draftPolicy.spec.desiredState = {
+          interfaces: [] as NodeNetworkConfigurationInterface[],
+        };
+      }
+
+      draftPolicy.spec.desiredState.interfaces.unshift({
+        type: InterfaceType.LINUX_BRIDGE,
+        name: `interface-${draftPolicy.spec.desiredState.interfaces.length}`,
+        state: 'up',
+        bridge: {
+          options: {
+            stp: {
+              enabled: false,
+            },
+          },
+        },
+      } as NodeNetworkConfigurationInterface);
+    });
+  };
+
+  const isOVSBridge = isOVSBridgeExisting(policy);
+
+  return (
+    <Form>
+      <div>
+        <Title headingLevel="h3">
+          {t('Policy Interface(s)')}{' '}
+          <Popover
+            aria-label={'Help'}
+            bodyContent={t(
+              'List of network interfaces that should be created, modified, or removed, as a part of this policy.',
+            )}
+          >
+            <Button variant="plain" hasNoPadding icon={<HelpIcon />} />
+          </Popover>
+        </Title>
+        <Content component="p" className="policy-form-content__add-new-interface pf-v6-u-mt-md">
+          <Button
+            icon={<PlusCircleIcon />}
+            className="pf-m-link--align-left pf-v6-u-ml-md"
+            onClick={addNewInterface}
+            variant={ButtonVariant.link}
+          >
+            <span>{t('Add another interface to the policy')}</span>
+          </Button>
+        </Content>
+        <PolicyInterfacesExpandable policy={policy} setPolicy={setPolicy} createForm />
+      </div>
+      {isOVSBridge && <PolicyFormOVSBridgeMapping policy={policy} setPolicy={setPolicy} />}
+
+      {error && (
+        <Alert
+          isInline
+          variant={AlertVariant.danger}
+          title={t('An error occurred')}
+          className="pf-v6-u-mt-md"
+        >
+          {error.message}
+        </Alert>
+      )}
+    </Form>
+  );
+};
+
+export default InterfacesStep;

--- a/src/utils/components/PolicyForm/PolicyWizard/PolicyWizard.tsx
+++ b/src/utils/components/PolicyForm/PolicyWizard/PolicyWizard.tsx
@@ -1,0 +1,63 @@
+import React, { FC, MouseEventHandler, useCallback, useState } from 'react';
+import { useNMStateTranslation } from 'src/utils/hooks/useNMStateTranslation';
+import { Updater } from 'use-immer';
+
+import { Wizard, WizardStep } from '@patternfly/react-core';
+import { V1NodeNetworkConfigurationPolicy } from '@types';
+import { isEmpty } from '@utils/helpers';
+
+import BasicInfoStep from './BasicInfoStep';
+import InterfacesStep from './InterfacesStep';
+
+import '../policy-form.scss';
+import './policy-wizard.scss';
+
+type PolicyWizardProps = {
+  policy: V1NodeNetworkConfigurationPolicy;
+  setPolicy: Updater<V1NodeNetworkConfigurationPolicy>;
+  onSubmit: () => void | Promise<void>;
+  onClose: () => void;
+};
+
+const PolicyWizard: FC<PolicyWizardProps> = ({ policy, setPolicy, onSubmit, onClose }) => {
+  const { t } = useNMStateTranslation();
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error>(null);
+
+  const onFormSubmit: MouseEventHandler<HTMLButtonElement> = useCallback(async () => {
+    setLoading(true);
+
+    try {
+      await onSubmit();
+    } catch (error) {
+      setError(error);
+    } finally {
+      setLoading(false);
+    }
+  }, [onSubmit]);
+
+  return (
+    <Wizard onSave={onFormSubmit} onClose={onClose} className="nmstate-policy-wizard">
+      <WizardStep
+        footer={{ isNextDisabled: isEmpty(policy.metadata.name) }}
+        id="policy-wizard-basicinfo"
+        name={t('Basic policy info')}
+      >
+        <BasicInfoStep policy={policy} setPolicy={setPolicy} />
+      </WizardStep>
+      <WizardStep
+        id="policy-wizard-interfaces"
+        name={t('Policy interfaces')}
+        footer={{
+          nextButtonProps: { isLoading: loading },
+          isNextDisabled: loading,
+          nextButtonText: 'Save',
+        }}
+      >
+        <InterfacesStep policy={policy} setPolicy={setPolicy} error={error} />
+      </WizardStep>
+    </Wizard>
+  );
+};
+
+export default PolicyWizard;

--- a/src/utils/components/PolicyForm/PolicyWizard/policy-wizard.scss
+++ b/src/utils/components/PolicyForm/PolicyWizard/policy-wizard.scss
@@ -1,0 +1,3 @@
+.nmstate-policy-wizard .pf-v6-c-wizard__main-body {
+  padding-left: 0;
+}

--- a/src/utils/hooks/useQueryParams.ts
+++ b/src/utils/hooks/useQueryParams.ts
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { useLocation } from 'react-router';
+import { useLocation } from 'react-router-dom-v5-compat';
 
 const useQueryParams = () => {
   const { search } = useLocation();

--- a/src/views/hostnetworkconfiguration/components/TopologySidebar/CreatePolicyDrawer.tsx
+++ b/src/views/hostnetworkconfiguration/components/TopologySidebar/CreatePolicyDrawer.tsx
@@ -1,0 +1,34 @@
+import React, { FC } from 'react';
+import { useHistory } from 'react-router';
+import NodeNetworkConfigurationPolicyModel from 'src/console-models/NodeNetworkConfigurationPolicyModel';
+import { useImmer } from 'use-immer';
+
+import { k8sCreate } from '@openshift-console/dynamic-plugin-sdk';
+import PolicyWizard from '@utils/components/PolicyForm/PolicyWizard/PolicyWizard';
+import { getResourceUrl } from '@utils/helpers';
+
+import { initialPolicy } from './constants';
+
+type CreatePolicyDrawerProps = {
+  onClose?: () => void;
+};
+
+const CreatePolicyDrawer: FC<CreatePolicyDrawerProps> = ({ onClose }) => {
+  const [policy, setPolicy] = useImmer(initialPolicy);
+  const history = useHistory();
+
+  const onSubmit = async () => {
+    await k8sCreate({
+      model: NodeNetworkConfigurationPolicyModel,
+      data: policy,
+    });
+
+    history.push(getResourceUrl({ model: NodeNetworkConfigurationPolicyModel, resource: policy }));
+  };
+
+  return (
+    <PolicyWizard policy={policy} setPolicy={setPolicy} onSubmit={onSubmit} onClose={onClose} />
+  );
+};
+
+export default CreatePolicyDrawer;

--- a/src/views/hostnetworkconfiguration/components/TopologySidebar/Drawer.tsx
+++ b/src/views/hostnetworkconfiguration/components/TopologySidebar/Drawer.tsx
@@ -1,0 +1,44 @@
+import React, { FC } from 'react';
+import StateDetailsPage from 'src/views/states/details/StateDetailsPage';
+
+import { V1beta1NodeNetworkState } from '@types';
+import { isEmpty } from '@utils/helpers';
+import useQueryParams from '@utils/hooks/useQueryParams';
+
+import useSelectedResources from './hooks/useSelectedResources';
+import InterfaceDrawer from './InterfaceDrawer/InterfaceDrawer';
+import { CREATE_POLICY_QUERY_PARAM, SELECTED_ID_QUERY_PARAM } from './constants';
+import CreatePolicyDrawer from './CreatePolicyDrawer';
+import PolicyDrawer from './PolicyDrawer';
+
+type DrawerProps = {
+  states: V1beta1NodeNetworkState[];
+  onClose: () => void;
+};
+
+const Drawer: FC<DrawerProps> = ({ states, onClose }) => {
+  const params = useQueryParams();
+
+  const selectedId = params?.[SELECTED_ID_QUERY_PARAM] || '';
+
+  const createPolicy = !isEmpty(params?.[CREATE_POLICY_QUERY_PARAM]);
+
+  const { selectedInterface, selectedPolicy, selectedState } = useSelectedResources(
+    selectedId,
+    states,
+  );
+
+  if (createPolicy) return <CreatePolicyDrawer onClose={onClose} />;
+
+  if (selectedInterface && !selectedPolicy)
+    return <InterfaceDrawer selectedInterface={selectedInterface} />;
+
+  if (selectedState && !selectedInterface) return <StateDetailsPage nns={selectedState} />;
+
+  if (selectedInterface && selectedPolicy)
+    return <PolicyDrawer selectedPolicy={selectedPolicy} selectedInterface={selectedInterface} />;
+
+  return null;
+};
+
+export default Drawer;

--- a/src/views/hostnetworkconfiguration/components/TopologySidebar/InterfaceDrawer/InterfaceDrawer.tsx
+++ b/src/views/hostnetworkconfiguration/components/TopologySidebar/InterfaceDrawer/InterfaceDrawer.tsx
@@ -44,7 +44,7 @@ const InterfaceDrawer: FC<InterfaceDrawerProps> = ({ selectedInterface }) => {
     tabs.find((tab) => tab.id === selectedTabId)?.component ?? tabs?.[0]?.component;
 
   return (
-    <>
+    <div className="nmstate-interface-drawer">
       <Title headingLevel="h1">{selectedInterface?.name}</Title>
       <div className="co-m-horizontal-nav">
         <TabsComponent activeKey={selectedTabId}>
@@ -66,7 +66,7 @@ const InterfaceDrawer: FC<InterfaceDrawerProps> = ({ selectedInterface }) => {
       {selectedTabId === 'drawer-yaml' && (
         <InterfaceDrawerYAMLFooter selectedInterface={selectedInterface} />
       )}
-    </>
+    </div>
   );
 };
 

--- a/src/views/hostnetworkconfiguration/components/TopologySidebar/TopologySidebar.scss
+++ b/src/views/hostnetworkconfiguration/components/TopologySidebar/TopologySidebar.scss
@@ -1,8 +1,30 @@
-.topology-sidebar {
-  &__content {
-    margin-top: 24px;
-    margin-left: 20px;
-    height: 100%;
+.nmstate-topology {
+  &__sidebar {
+    left: 0;
+    right: auto;
+
+    .nmstate-interface-drawer {
+      margin-top: 24px;
+      margin-left: 20px;
+    }
+
+    .nmstate-console-policy-drawer {
+      margin-left: 20px;
+    }
+
+    &__content {
+      height: 100%;
+    }
+  }
+
+  .pf-v6-c-wizard__nav {
+    width: 200px;
+  }
+}
+
+.pf-topology-side-bar.nmstate-topology__sidebar.big-sidebar {
+  @media (min-width: 768px) {
+    max-width: 700px;
   }
 }
 

--- a/src/views/hostnetworkconfiguration/components/TopologySidebar/TopologySidebar.tsx
+++ b/src/views/hostnetworkconfiguration/components/TopologySidebar/TopologySidebar.tsx
@@ -1,37 +1,42 @@
-import React, { Dispatch, FC, SetStateAction } from 'react';
+import React, { FC } from 'react';
+import { useHistory } from 'react-router';
+import classNames from 'classnames';
 
 import { TopologySideBar } from '@patternfly/react-topology';
 import { V1beta1NodeNetworkState } from '@types';
+import { isEmpty } from '@utils/helpers';
+import useQueryParams from '@utils/hooks/useQueryParams';
 
-import StateDetailsPage from '../../../states/details/StateDetailsPage';
-
-import useSelectedResources from './hooks/useSelectedResources';
-import InterfaceDrawer from './InterfaceDrawer/InterfaceDrawer';
-import PolicyDrawer from './PolicyDrawer';
+import { CREATE_POLICY_QUERY_PARAM, SELECTED_ID_QUERY_PARAM } from './constants';
+import Drawer from './Drawer';
 
 import './TopologySidebar.scss';
 
 type TopologySidebarProps = {
   states: V1beta1NodeNetworkState[];
-  selectedIds: string[];
-  setSelectedIds: Dispatch<SetStateAction<string[]>>;
 };
-const TopologySidebar: FC<TopologySidebarProps> = ({ states, selectedIds, setSelectedIds }) => {
-  const { selectedInterface, selectedPolicy, selectedState } = useSelectedResources(
-    selectedIds,
-    states,
-  );
-  return (
-    <TopologySideBar show={selectedIds.length > 0} onClose={() => setSelectedIds([])}>
-      <div className="topology-sidebar__content">
-        {selectedInterface && !selectedPolicy && (
-          <InterfaceDrawer selectedInterface={selectedInterface} />
-        )}
-        {selectedState && !selectedInterface && <StateDetailsPage nns={selectedState} />}
+const TopologySidebar: FC<TopologySidebarProps> = ({ states }) => {
+  const history = useHistory();
 
-        {selectedInterface && selectedPolicy && (
-          <PolicyDrawer selectedPolicy={selectedPolicy} selectedInterface={selectedInterface} />
-        )}
+  const queryParams = useQueryParams();
+
+  const selectedIDExist = !isEmpty(queryParams?.[SELECTED_ID_QUERY_PARAM]);
+  const createPolicyDrawer = !isEmpty(queryParams?.[CREATE_POLICY_QUERY_PARAM]);
+
+  const showSidebar = selectedIDExist || createPolicyDrawer;
+
+  const closeDrawer = () => {
+    history.push({ search: new URLSearchParams({}).toString() });
+  };
+
+  return (
+    <TopologySideBar
+      show={showSidebar}
+      onClose={selectedIDExist ? closeDrawer : null}
+      className={classNames('nmstate-topology__sidebar', { 'big-sidebar': createPolicyDrawer })}
+    >
+      <div className="nmstate-topology__sidebar__content">
+        <Drawer states={states} onClose={closeDrawer} />
       </div>
     </TopologySideBar>
   );

--- a/src/views/hostnetworkconfiguration/components/TopologySidebar/constants.ts
+++ b/src/views/hostnetworkconfiguration/components/TopologySidebar/constants.ts
@@ -1,0 +1,37 @@
+import NodeNetworkConfigurationPolicyModel from 'src/console-models/NodeNetworkConfigurationPolicyModel';
+
+import {
+  InterfaceType,
+  NodeNetworkConfigurationInterface,
+  V1NodeNetworkConfigurationPolicy,
+} from '@types';
+import { NETWORK_STATES } from '@utils/components/PolicyForm/constants';
+
+export const initialPolicy: V1NodeNetworkConfigurationPolicy = {
+  apiVersion: `${NodeNetworkConfigurationPolicyModel.apiGroup}/${NodeNetworkConfigurationPolicyModel.apiVersion}`,
+  kind: NodeNetworkConfigurationPolicyModel.kind,
+  metadata: {
+    name: 'policy-name',
+  },
+  spec: {
+    desiredState: {
+      interfaces: [
+        {
+          name: 'br0',
+          type: InterfaceType.LINUX_BRIDGE,
+          state: NETWORK_STATES.Up,
+          bridge: {
+            options: {
+              stp: {
+                enabled: false,
+              },
+            },
+          },
+        } as NodeNetworkConfigurationInterface,
+      ],
+    },
+  },
+};
+
+export const SELECTED_ID_QUERY_PARAM = 'selectedID';
+export const CREATE_POLICY_QUERY_PARAM = 'createPolicy';

--- a/src/views/hostnetworkconfiguration/components/TopologySidebar/hooks/useSelectedID.ts
+++ b/src/views/hostnetworkconfiguration/components/TopologySidebar/hooks/useSelectedID.ts
@@ -1,0 +1,11 @@
+import useQueryParams from '@utils/hooks/useQueryParams';
+
+import { SELECTED_ID_QUERY_PARAM } from '../constants';
+
+const useSelectedID = () => {
+  const params = useQueryParams();
+
+  return params?.[SELECTED_ID_QUERY_PARAM] || '';
+};
+
+export default useSelectedID;

--- a/src/views/hostnetworkconfiguration/components/TopologySidebar/hooks/useSelectedResources.ts
+++ b/src/views/hostnetworkconfiguration/components/TopologySidebar/hooks/useSelectedResources.ts
@@ -9,11 +9,12 @@ import {
   V1beta1NodeNetworkConfigurationPolicy,
   V1beta1NodeNetworkState,
 } from '@types';
+import { isEmpty } from '@utils/helpers';
 
 import { isPolicyAppliedInNode } from '../utils';
 
 const useSelectedResources = (
-  selectedIds: string[],
+  selectedId: string,
   states: V1beta1NodeNetworkState[],
 ): {
   selectedState?: V1beta1NodeNetworkState;
@@ -33,9 +34,9 @@ const useSelectedResources = (
   });
 
   return useMemo(() => {
-    if (selectedIds.length === 0) return { selectedState: null, selectedPolicy: null };
+    if (isEmpty(selectedId)) return { selectedState: null, selectedPolicy: null };
 
-    const [selectedNNSName, selectedInterfaceName] = selectedIds[0].split('~');
+    const [selectedNNSName, selectedInterfaceName] = selectedId.split('~');
     const selectedNode = nodes?.find((node) => node.metadata.name === selectedNNSName);
 
     const selectedPolicy = policies?.find(
@@ -53,7 +54,7 @@ const useSelectedResources = (
     );
 
     return { selectedState, selectedPolicy, selectedInterface };
-  }, [selectedIds, states, policies, nodes]);
+  }, [selectedId, states, policies, nodes]);
 };
 
 export default useSelectedResources;

--- a/src/views/hostnetworkconfiguration/components/TopologyToolbar/TopologyToolbar.tsx
+++ b/src/views/hostnetworkconfiguration/components/TopologyToolbar/TopologyToolbar.tsx
@@ -1,7 +1,10 @@
 import React, { Dispatch, FC, SetStateAction } from 'react';
+import { useHistory } from 'react-router';
 import { useNavigate } from 'react-router-dom-v5-compat';
+import NodeNetworkConfigurationPolicyModel from 'src/console-models/NodeNetworkConfigurationPolicyModel';
 
-import { NodeNetworkStateModelRef } from '@models';
+import { NodeNetworkConfigurationPolicyModelRef, NodeNetworkStateModelRef } from '@models';
+import { ListPageCreateDropdown } from '@openshift-console/dynamic-plugin-sdk';
 import {
   Button,
   Title,
@@ -11,7 +14,10 @@ import {
   ToolbarItem,
 } from '@patternfly/react-core';
 import { ListIcon } from '@patternfly/react-icons';
+import { getResourceUrl } from '@utils/helpers';
 import { useNMStateTranslation } from '@utils/hooks/useNMStateTranslation';
+
+import { CREATE_POLICY_QUERY_PARAM } from '../TopologySidebar/constants';
 
 import TopologyToolbarFilter from './TopologyToolbarFilter';
 
@@ -27,6 +33,24 @@ const TopologyButton: FC<TopologyToolbarProps> = (props) => {
   const { t } = useNMStateTranslation();
   const navigate = useNavigate();
   const setSelectedNodeFilters = props.setSelectedNodeFilters;
+  const history = useHistory();
+
+  const createItems = {
+    form: t('From Form'),
+    yaml: t('With YAML'),
+  };
+
+  const onCreate = (type: string) => {
+    const baseURL = getResourceUrl({
+      model: NodeNetworkConfigurationPolicyModel,
+    });
+
+    const newParams = new URLSearchParams({ [CREATE_POLICY_QUERY_PARAM]: 'true' });
+
+    return type === 'form'
+      ? history.push({ search: newParams.toString() })
+      : history.push(`${baseURL}~new`);
+  };
 
   return (
     <Toolbar className="topology-toolbar" clearAllFilters={() => setSelectedNodeFilters([])}>
@@ -34,9 +58,15 @@ const TopologyButton: FC<TopologyToolbarProps> = (props) => {
         <ToolbarGroup>
           <Title headingLevel="h2">{t('Host network configuration')}</Title>
 
-          <Button isInline onClick={() => navigate(`/k8s/cluster/${NodeNetworkStateModelRef}`)}>
+          <ListPageCreateDropdown
+            items={createItems}
+            onClick={onCreate}
+            createAccessReview={{
+              groupVersionKind: NodeNetworkConfigurationPolicyModelRef,
+            }}
+          >
             {t('Create')}
-          </Button>
+          </ListPageCreateDropdown>
           <TopologyToolbarFilter {...props} />
         </ToolbarGroup>
         <ToolbarGroup>

--- a/src/views/policies/details/PolicyDetailsPage.tsx
+++ b/src/views/policies/details/PolicyDetailsPage.tsx
@@ -33,7 +33,7 @@ const PolicyDetailsPage: FC<PolicyDetailsPageProps> = ({ obj: policy, iface }) =
   });
 
   const policyMatchedNodes = getMatchedPolicyNodes(policy, nodes);
-  const interfaceToShow = getInterfaceToShow(policy, iface.name);
+  const interfaceToShow = getInterfaceToShow(policy, iface?.name);
 
   const dnsResolver = policy?.spec?.desiredState?.['dns-resolver'];
 


### PR DESCRIPTION
design: https://www.figma.com/design/kRzubietP5jCps5lPjlGEP/OCP%2FCNV-secondary-networking?node-id=2-30&p=f&t=5xncSmfMSO5FnW5Z-0


Things to do in a following pr:

- Split add interface menu info into the different type of interfaces (bridge, bonding, basic)
- make the create drawer open the policy drawer after creation. 
- adjust the UI and remove some padding in the wizard content.

Things to know: I added the state in the query params so that if the user refresh the page or share it with someone, it will open the drawer anyways

**Demo**


https://github.com/user-attachments/assets/5c995ff0-a872-40b1-bbea-adb2602820f5



**UI fixes**

<img width="1919" alt="Screenshot 2025-04-01 at 15 02 43" src="https://github.com/user-attachments/assets/3b0224bb-4004-4b66-b195-f4c0c645ffc5" />
