### PR TITLE
CNV-61531: Fix topology view button link

### DIFF
--- a/src/views/states/list/StatesList.tsx
+++ b/src/views/states/list/StatesList.tsx
@@ -87,7 +87,7 @@ const StatesList: FC = () => {
             }
             isInline
             variant="plain"
-            onClick={() => navigate('/host-network-configuration')}
+            onClick={() => navigate('/node-network-configuration')}
           />
         )}
       </ListPageHeader>


### PR DESCRIPTION
This PR fixes a broken link for the topology view button on the "Node network configuration" page.

Jira: https://issues.redhat.com/browse/CNV-61531

## Demo

[node-network-topology-view-button--AFTER--2025-05-12 09-47.webm](https://github.com/user-attachments/assets/761ca23e-4888-40d6-83c7-ae6457816b4c)
