### PR TITLE
Fix nmstate tests

### DIFF
--- a/cypress/e2e/StatusList.spec.cy.ts
+++ b/cypress/e2e/StatusList.spec.cy.ts
@@ -3,7 +3,8 @@ import {
   EXPAND_INTERFACES_LIST_TEST_ID,
   INTERFACE_DRAWER_TEST_ID,
   LLDP_DRAWER_DETAILS_SECTION_TEST_ID,
-  SEARCH_FILTER_DROPDOWN,
+  SEARCH_FILTER_DROPDOWN_TEST_ID,
+  TEXT_FILTER_BUTTON_SELECTOR,
 } from '../support/selectors';
 
 describe('NodeNetworkState list', () => {
@@ -144,9 +145,9 @@ describe('NodeNetworkState list', () => {
 
       cy.get('table').should('contain', nns.metadata.name);
 
-      cy.get(SEARCH_FILTER_DROPDOWN).click();
+      cy.byTestID(SEARCH_FILTER_DROPDOWN_TEST_ID).click();
 
-      cy.get('#filter-toolbar button').contains('LLDP VLAN name').click();
+      cy.get(TEXT_FILTER_BUTTON_SELECTOR).contains('LLDP VLAN name').click();
 
       cy.get('input[data-test-id="item-filter"]').type(VLAN_NAME);
 
@@ -182,9 +183,9 @@ describe('NodeNetworkState list', () => {
 
       cy.get('table').should('contain', nns.metadata.name);
 
-      cy.get(SEARCH_FILTER_DROPDOWN).click();
+      cy.byTestID(SEARCH_FILTER_DROPDOWN_TEST_ID).click();
 
-      cy.get('#filter-toolbar button').contains('LLDP system name').click();
+      cy.get(TEXT_FILTER_BUTTON_SELECTOR).contains('LLDP system name').click();
 
       cy.get('input[data-test-id="item-filter"]').type(SYSTEM_NAME);
 

--- a/cypress/support/selectors.ts
+++ b/cypress/support/selectors.ts
@@ -3,6 +3,8 @@ export const EXPAND_INTERFACE_INFO = 'ethernet-expandable-section-toggle';
 export const INTERFACE_DRAWER_TEST_ID = 'interface-drawer';
 export const LLDP_DRAWER_DETAILS_SECTION_TEST_ID = 'lldp-section';
 
-export const SEARCH_FILTER_DROPDOWN = 'button[data-test-id="dropdown-button"]';
+export const SEARCH_FILTER_DROPDOWN_TEST_ID = 'console-select-menu-toggle';
+export const TEXT_FILTER_BUTTON_SELECTOR =
+  '.pf-v6-c-menu li.pf-v6-c-menu__list-item button.pf-v6-c-menu__item';
 
 export const SKIP_WELCOME_BANNER_TEST_ID = 'tour-step-footer-secondary';


### PR DESCRIPTION
in 4.20 the `data-test-id` was removed to have a new `data-test`. The previous `data-test-id` seemed generic and now more specific so i assume it will not change again 