### PR TITLE
OCPBUGS-79422: fix single interface uplink validation in NNCP wizard

### DIFF
--- a/src/utils/components/PolicyForm/PolicyWizard/utils/constants.ts
+++ b/src/utils/components/PolicyForm/PolicyWizard/utils/constants.ts
@@ -5,6 +5,6 @@ export const DEFAULT_OVS_BRIDGE_NAME = 'ovs-br1';
 export const DEFAULT_OVS_INTERFACE_NAME = 'ovs-br1';
 
 export const MIN_NUM_INTERFACES_FOR_BOND = 2;
-export const NUM_INTERFACES_FOR_SINGLE_INTERFACE_UPLINK = 1;
+export const NUM_INTERFACES_FOR_SINGLE_INTERFACE_UPLINK = 2;
 
 export const WORKER_NODE_LABEL = 'node-role.kubernetes.io/worker';


### PR DESCRIPTION
## Summary
- Fix the "Next" button being permanently disabled when selecting a NIC in the "A single interface" uplink connection option of the NNCP creation wizard.
- The validation expected exactly 1 bridge port, but selecting a NIC sets 2 ports (physical NIC + OVS internal interface `ovs-br1`). Updated `NUM_INTERFACES_FOR_SINGLE_INTERFACE_UPLINK` from 1 to 2.
- This also fixes a secondary issue where the "Next" button was incorrectly enabled before any NIC was selected.


**DEMO**

https://github.com/user-attachments/assets/8a211d9e-e2fb-4e20-a9b3-183814323762


## Test plan
- [ ] Create NNCP from form
- [ ] Move to Uplink connection and select "A single interface"
- [ ] Select an interface — verify the "Next" button is now enabled
- [ ] Verify that before selecting any NIC, the "Next" button is disabled


Made with [Cursor](https://cursor.com)