### PR TITLE
OCPBUGS-82150: [release-4.21] fix null safety guards to prevent runtime crashes

### DIFF
--- a/src/utils/components/PolicyForm/PolicyWizard/utils/hooks/useNodeInterfaces/utils/utils.ts
+++ b/src/utils/components/PolicyForm/PolicyWizard/utils/hooks/useNodeInterfaces/utils/utils.ts
@@ -23,7 +23,7 @@ const getUsedPortNamesForNode = (nns: V1beta1NodeNetworkState) => {
   const interfaces = getInterfaces(nns);
   return interfaces.reduce((acc, iface) => {
     if (bridgeTypes.includes(iface?.type)) {
-      const ports = iface?.bridge?.port?.map((port) => port?.name);
+      const ports = iface?.bridge?.port?.map((port) => port?.name) || [];
       acc = [...acc, ...ports];
     }
 

--- a/src/utils/resources/enactments/utils.ts
+++ b/src/utils/resources/enactments/utils.ts
@@ -1,7 +1,7 @@
 import { V1beta1NodeNetworkConfigurationEnactment } from '@kubevirt-ui/kubevirt-api/nmstate';
 
 export const getEnactmentStatus = (enactment: V1beta1NodeNetworkConfigurationEnactment): string =>
-  enactment?.status?.conditions?.find((condition) => condition.status === 'True').type;
+  enactment?.status?.conditions?.find((condition) => condition.status === 'True')?.type;
 
 export const categorizeEnactments = (enactments: V1beta1NodeNetworkConfigurationEnactment[]) => {
   return (enactments || []).reduce(

--- a/src/utils/resources/policies/utils.ts
+++ b/src/utils/resources/policies/utils.ts
@@ -33,7 +33,7 @@ export const isPolicyAppliedInNode = (
 export const filterPolicyAppliedNodes = (
   nodes: IoK8sApiCoreV1Node[],
   policy: V1NodeNetworkConfigurationPolicy,
-) => nodes.filter((node) => isPolicyAppliedInNode(policy, node));
+) => (nodes || []).filter((node) => isPolicyAppliedInNode(policy, node));
 
 export const getPolicyInterfaces = (
   policy: V1NodeNetworkConfigurationPolicy,


### PR DESCRIPTION
## Summary
- Backport of 57f2cfc from main to release-4.21
- Adds null safety guards to prevent runtime crashes in the NNCP form when API data is missing or has unexpected structure

## Test plan
- [ ] Open the NNCP form wizard and verify it no longer crashes
- [ ] Verify policy enactment status displays correctly with missing data

Made with [Cursor](https://cursor.com)