### PR TITLE
CNV-50319: update NNCP empty state message

### DIFF
--- a/locales/en/plugin__nmstate-console-plugin.json
+++ b/locales/en/plugin__nmstate-console-plugin.json
@@ -171,7 +171,7 @@
   "Network types": "Network types",
   "No": "No",
   "No matching Nodes found for the labels": "No matching Nodes found for the labels",
-  "No NodeNetworkConfigurationPolicy defined yet": "No NodeNetworkConfigurationPolicy defined yet",
+  "No NodeNetworkConfigurationPolicy found": "No NodeNetworkConfigurationPolicy found",
   "No NodeNetworkStates found": "No NodeNetworkStates found",
   "No owner": "No owner",
   "No physical networks defined yet": "No physical networks defined yet",

--- a/locales/es/plugin__nmstate-console-plugin.json
+++ b/locales/es/plugin__nmstate-console-plugin.json
@@ -176,7 +176,7 @@
   "Network types": "Tipos de red",
   "No": "No",
   "No matching Nodes found for the labels": "No se encontraron nodos coincidentes para las etiquetas",
-  "No NodeNetworkConfigurationPolicy defined yet": "NodeNetworkConfigurationPolicy aún no está definido",
+  "No NodeNetworkConfigurationPolicy found": "",
   "No NodeNetworkStates found": "No se encontraron NodeNetworkStates",
   "No owner": "Sin propietario",
   "No physical networks defined yet": "",

--- a/locales/fr/plugin__nmstate-console-plugin.json
+++ b/locales/fr/plugin__nmstate-console-plugin.json
@@ -176,7 +176,7 @@
   "Network types": "Types de réseaux",
   "No": "Non",
   "No matching Nodes found for the labels": "Aucun nœud correspondant trouvé pour les étiquettes",
-  "No NodeNetworkConfigurationPolicy defined yet": "Aucune politique de configuration réseau de nœuds n'a encore été définie.",
+  "No NodeNetworkConfigurationPolicy found": "",
   "No NodeNetworkStates found": "Aucun NodeNetworkStates trouvé",
   "No owner": "Aucun propriétaire",
   "No physical networks defined yet": "",

--- a/locales/ja/plugin__nmstate-console-plugin.json
+++ b/locales/ja/plugin__nmstate-console-plugin.json
@@ -171,7 +171,7 @@
   "Network types": "ネットワークタイプ",
   "No": "No",
   "No matching Nodes found for the labels": "ラベルに一致するノードが見つかりません",
-  "No NodeNetworkConfigurationPolicy defined yet": "NodeNetworkConfigurationPolicy はまだ定義されていません",
+  "No NodeNetworkConfigurationPolicy found": "",
   "No NodeNetworkStates found": "NodeNetworkStates が見つかりません",
   "No owner": "所有者なし",
   "No physical networks defined yet": "",

--- a/locales/ko/plugin__nmstate-console-plugin.json
+++ b/locales/ko/plugin__nmstate-console-plugin.json
@@ -171,7 +171,7 @@
   "Network types": "네트워크 유형",
   "No": "아니요",
   "No matching Nodes found for the labels": "라벨과 일치하는 노드가 없음",
-  "No NodeNetworkConfigurationPolicy defined yet": "NodeNetworkConfigurationPolicy가 아직 정의되어 있지 않음",
+  "No NodeNetworkConfigurationPolicy found": "",
   "No NodeNetworkStates found": "NodeNetworkStates를 찾을 수 없음",
   "No owner": "소유자 없음",
   "No physical networks defined yet": "",

--- a/locales/zh/plugin__nmstate-console-plugin.json
+++ b/locales/zh/plugin__nmstate-console-plugin.json
@@ -171,7 +171,7 @@
   "Network types": "网络类型",
   "No": "否",
   "No matching Nodes found for the labels": "没有找到与标签匹配的节点",
-  "No NodeNetworkConfigurationPolicy defined yet": "还没有定义 NodeNetworkConfigurationPolicy",
+  "No NodeNetworkConfigurationPolicy found": "",
   "No NodeNetworkStates found": "没有找到 NodeNetworkStates",
   "No owner": "没有所有者",
   "No physical networks defined yet": "",

--- a/src/views/policies/list/components/PolicyListEmptyState/PolicyListEmptyState.tsx
+++ b/src/views/policies/list/components/PolicyListEmptyState/PolicyListEmptyState.tsx
@@ -25,7 +25,7 @@ const PolicyListEmptyState: FC = () => {
 
   return (
     <EmptyState
-      titleText={t('No NodeNetworkConfigurationPolicy defined yet')}
+      titleText={t('No NodeNetworkConfigurationPolicy found')}
       headingLevel="h4"
       icon={() => <img src={EmptyPolicyStateImage} className="policy-empty-state-icon" />}
       variant={EmptyStateVariant.lg}


### PR DESCRIPTION
## Summary
- Update the NNCP list empty state text from "No NodeNetworkConfigurationPolicy defined yet" to "No NodeNetworkConfigurationPolicy found"

## Test plan
- [ ] Navigate to the NodeNetworkConfigurationPolicy list page with no policies created
- [ ] Verify the empty state message reads "No NodeNetworkConfigurationPolicy found"

Made with [Cursor](https://cursor.com)