### PR TITLE
release-4.21: simplify Dockerfile.art builder (npm ci, Cypress env)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+node_modules
+.git
+dist
+coverage
+tmp
+*.log
+.cypress

--- a/Dockerfile.art
+++ b/Dockerfile.art
@@ -1,19 +1,16 @@
 # Builder container
 FROM registry.ci.openshift.org/ocp/builder:rhel-9-base-nodejs-openshift-4.21 AS build
+ENV CYPRESS_INSTALL_BINARY 0
 
 # Copy app source
 COPY . /opt/app-root/src/app
 COPY $REMOTE_SOURCES $REMOTE_SOURCES_DIR
 WORKDIR /opt/app-root/src/app
 
-# use dependencies provided by Cachito
 USER 0
-RUN test -d ${REMOTE_SOURCES_DIR}/cachito-gomod-with-deps || exit 1; \
-    cp -f $REMOTE_SOURCES_DIR/cachito-gomod-with-deps/app/{.npmrc,package-lock.json,registry-ca.pem} . \
- && source ${REMOTE_SOURCES_DIR}/cachito-gomod-with-deps/cachito.env \
- && npm ci && \
-    npm install --no-save @esbuild/linux-x64 && \
-    npm run build
+# Install devDependencies for the build, and optional deps (esbuild platform binaries).
+# Some bases set NODE_ENV=production (omit=dev) or omit=optional in npm config.
+RUN npm ci --include=dev --include=optional && npm run build
 
 # Web server container
 FROM registry.ci.openshift.org/ocp/4.21:base-rhel9


### PR DESCRIPTION
## Changes

- Set `ENV CYPRESS_INSTALL_BINARY 0` in the builder stage.
- Replace the Cachito-based copy/source/npm ci/esbuild install block with a single `RUN npm ci && npm run build`.

## Note

Opened via gh CLI.

Made with [Cursor](https://cursor.com)