### PR TITLE
CNV-84061: show default MTU info in NNCP form + fixes

### DIFF
--- a/locales/en/plugin__nmstate-console-plugin.json
+++ b/locales/en/plugin__nmstate-console-plugin.json
@@ -1,4 +1,6 @@
 {
+  "({{inheritedMTU}} from existing bridge)": "({{inheritedMTU}} from existing bridge)",
+  "({{inheritedMTU}} from uplink)": "({{inheritedMTU}} from uplink)",
   "(IPv4)": "(IPv4)",
   "{{annotationsCount}} Annotations": "{{annotationsCount}} Annotations",
   "{{count}} aborted enactments_one": "{{count}} aborted enactment",
@@ -32,8 +34,8 @@
   "An error occurred": "An error occurred",
   "Annotations": "Annotations",
   "Apply this only to specific subsets of nodes using the node selector": "Apply this only to specific subsets of nodes using the node selector",
-  "Apply to all the nodes on the cluster": "Apply to all the nodes on the cluster",
-  "Apply to specific subsets of Nodes using the Nodes selector": "Apply to specific subsets of Nodes using the Nodes selector",
+  "Apply to all the worker nodes on the cluster": "Apply to all the worker nodes on the cluster",
+  "Apply to specific subsets of nodes using the node selector": "Apply to specific subsets of nodes using the node selector",
   "Are you sure you want to remove {{interfaceType}} interface <5>{{name}}</5>?": "Are you sure you want to remove {{interfaceType}} interface <5>{{name}}</5>?",
   "Auto-DNS": "Auto-DNS",
   "Auto-gateway": "Auto-gateway",

--- a/locales/es/plugin__nmstate-console-plugin.json
+++ b/locales/es/plugin__nmstate-console-plugin.json
@@ -1,4 +1,6 @@
 {
+  "({{inheritedMTU}} from existing bridge)": "",
+  "({{inheritedMTU}} from uplink)": "",
   "(IPv4)": "(IPv4)",
   "{{annotationsCount}} Annotations": "{{annotationsCount}} anotaciones",
   "{{count}} aborted enactments_one": "{{count}} promulgación abortada_one",
@@ -37,8 +39,8 @@
   "An error occurred": "Ocurrió un error",
   "Annotations": "Anotaciones",
   "Apply this only to specific subsets of nodes using the node selector": "Aplicar esto solo a subconjuntos específicos de nodos con el selector de nodos",
-  "Apply to all the nodes on the cluster": "Aplicar a todos los nodos del clúster",
-  "Apply to specific subsets of Nodes using the Nodes selector": "Aplicar a subconjuntos específicos de nodos con el selector de nodos",
+  "Apply to all the worker nodes on the cluster": "",
+  "Apply to specific subsets of nodes using the node selector": "",
   "Are you sure you want to remove {{interfaceType}} interface <5>{{name}}</5>?": "¿Confirma que desea eliminar la interfaz {{interfaceType}} <5>{{name}}</5>?",
   "Auto-DNS": "DNS automático",
   "Auto-gateway": "Puerta de enlace automática",

--- a/locales/fr/plugin__nmstate-console-plugin.json
+++ b/locales/fr/plugin__nmstate-console-plugin.json
@@ -1,4 +1,6 @@
 {
+  "({{inheritedMTU}} from existing bridge)": "",
+  "({{inheritedMTU}} from uplink)": "",
   "(IPv4)": "(IPv4)",
   "{{annotationsCount}} Annotations": "{{annotationsCount}} Annotations",
   "{{count}} aborted enactments_one": "{{count}} actes d'adoption avortés_un",
@@ -37,8 +39,8 @@
   "An error occurred": "Une erreur s’est produite",
   "Annotations": "Annotations",
   "Apply this only to specific subsets of nodes using the node selector": "Appliquez ceci uniquement à des sous-ensembles spécifiques de nœuds à l'aide du sélecteur de nœuds.",
-  "Apply to all the nodes on the cluster": "Appliquer à tous les nœuds du cluster",
-  "Apply to specific subsets of Nodes using the Nodes selector": "Appliquer à des sous-ensembles spécifiques de nœuds à l'aide du sélecteur de nœuds",
+  "Apply to all the worker nodes on the cluster": "",
+  "Apply to specific subsets of nodes using the node selector": "",
   "Are you sure you want to remove {{interfaceType}} interface <5>{{name}}</5>?": "Êtes-vous sûr de vouloir supprimer{{interfaceType}} interface<5>{{name}}</5> ?",
   "Auto-DNS": "Auto-DNS",
   "Auto-gateway": "Auto-gateway",

--- a/locales/ja/plugin__nmstate-console-plugin.json
+++ b/locales/ja/plugin__nmstate-console-plugin.json
@@ -1,4 +1,6 @@
 {
+  "({{inheritedMTU}} from existing bridge)": "",
+  "({{inheritedMTU}} from uplink)": "",
   "(IPv4)": "(IPv4)",
   "{{annotationsCount}} Annotations": "{{annotationsCount}} 個のアノテーション",
   "{{count}} aborted enactments_one": "中止された施行: {{count}} 件",
@@ -32,8 +34,8 @@
   "An error occurred": "エラーが発生しました",
   "Annotations": "アノテーション",
   "Apply this only to specific subsets of nodes using the node selector": "ノードセレクターを使用して、特定のノードサブセットにのみこれを適用します",
-  "Apply to all the nodes on the cluster": "クラスター上のすべてのノードに適用します",
-  "Apply to specific subsets of Nodes using the Nodes selector": "ノードセレクターを使用して、特定のノードサブセットに適用します",
+  "Apply to all the worker nodes on the cluster": "",
+  "Apply to specific subsets of nodes using the node selector": "",
   "Are you sure you want to remove {{interfaceType}} interface <5>{{name}}</5>?": "{{interfaceType}} インターフェイス <5>{{name}}</5> を削除してもよろしいですか?",
   "Auto-DNS": "自動 DNS",
   "Auto-gateway": "自動ゲートウェイ",

--- a/locales/ko/plugin__nmstate-console-plugin.json
+++ b/locales/ko/plugin__nmstate-console-plugin.json
@@ -1,4 +1,6 @@
 {
+  "({{inheritedMTU}} from existing bridge)": "",
+  "({{inheritedMTU}} from uplink)": "",
   "(IPv4)": "(IPv4)",
   "{{annotationsCount}} Annotations": "{{annotationsCount}} 주석",
   "{{count}} aborted enactments_one": "{{count}} 중단된 실행",
@@ -32,8 +34,8 @@
   "An error occurred": "오류가 발생했습니다",
   "Annotations": "주석",
   "Apply this only to specific subsets of nodes using the node selector": "노드 선택기를 사용하여 특정 노드 하위 집합에만 적용합니다",
-  "Apply to all the nodes on the cluster": "클러스터의 모든 노드에 적용합니다",
-  "Apply to specific subsets of Nodes using the Nodes selector": "노드 선택기를 사용하여 노드의 특정 하위 집합에 적용합니다",
+  "Apply to all the worker nodes on the cluster": "",
+  "Apply to specific subsets of nodes using the node selector": "",
   "Are you sure you want to remove {{interfaceType}} interface <5>{{name}}</5>?": "{{interfaceType}} 인터페이스 <5>{{name}}</5> 를 제거하시겠습니까?",
   "Auto-DNS": "Auto-DNS",
   "Auto-gateway": "Auto-gateway",

--- a/locales/zh/plugin__nmstate-console-plugin.json
+++ b/locales/zh/plugin__nmstate-console-plugin.json
@@ -1,4 +1,6 @@
 {
+  "({{inheritedMTU}} from existing bridge)": "",
+  "({{inheritedMTU}} from uplink)": "",
   "(IPv4)": "(IPv4)",
   "{{annotationsCount}} Annotations": "{{annotationsCount}} 注解",
   "{{count}} aborted enactments_one": "{{count}} 个中止的 enactments",
@@ -32,8 +34,8 @@
   "An error occurred": "发生错误",
   "Annotations": "注解",
   "Apply this only to specific subsets of nodes using the node selector": "只应用到使用节点选择器的节点子集",
-  "Apply to all the nodes on the cluster": "应用到集群中的所有节点",
-  "Apply to specific subsets of Nodes using the Nodes selector": "应用到使用节点选择器的节点子集",
+  "Apply to all the worker nodes on the cluster": "",
+  "Apply to specific subsets of nodes using the node selector": "",
   "Are you sure you want to remove {{interfaceType}} interface <5>{{name}}</5>?": "您确定要删除 {{interfaceType}} 接口 <5>{{name}}</5> 吗？",
   "Auto-DNS": "Auto-DNS",
   "Auto-gateway": "Auto-gateway",

--- a/src/utils/components/PolicyForm/PolicyWizard/PolicyWizard.tsx
+++ b/src/utils/components/PolicyForm/PolicyWizard/PolicyWizard.tsx
@@ -52,6 +52,8 @@ const PolicyWizard: FC<PolicyWizardProps> = ({
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<Error>(null);
 
+  const invalidUplinkSettings = !uplinkSettingsValid(policy);
+
   const onFormSubmit: MouseEventHandler<HTMLButtonElement> = useCallback(async () => {
     const error = ensureNoEmptyBridgeMapping(policy);
 
@@ -93,14 +95,16 @@ const PolicyWizard: FC<PolicyWizardProps> = ({
       <WizardStep
         id="policy-wizard-uplink-connection"
         name={t('Uplink connection')}
-        footer={{ isNextDisabled: !uplinkSettingsValid(policy) }}
+        footer={{ isNextDisabled: invalidUplinkSettings }}
       >
         <UplinkConnectionStep policy={policy} setPolicy={setPolicy} />
       </WizardStep>
       <WizardStep
         name={t('Settings')}
         id="policy-wizard-configuration"
-        isDisabled={getUplinkConnectionOption(policy) === ConnectionOption.BREX}
+        isDisabled={
+          getUplinkConnectionOption(policy) === ConnectionOption.BREX || invalidUplinkSettings
+        }
       >
         <SettingsStep policy={policy} setPolicy={setPolicy} />
       </WizardStep>
@@ -112,6 +116,7 @@ const PolicyWizard: FC<PolicyWizardProps> = ({
         }}
         id="policy-wizard-review"
         name={t('Review and create')}
+        isDisabled={invalidUplinkSettings}
       >
         <ReviewStep
           policy={policy}

--- a/src/utils/components/PolicyForm/PolicyWizard/steps/NodesConfigurationStep/components/NodeSelectionRadioGroup.tsx
+++ b/src/utils/components/PolicyForm/PolicyWizard/steps/NodesConfigurationStep/components/NodeSelectionRadioGroup.tsx
@@ -48,7 +48,7 @@ const NodeSelectionRadioGroup: FC<NodeSelectionRadioGroupProps> = ({ policy, set
           <Radio
             id="node-selection-radio-all"
             isChecked={nodeSelectionOption === NodeSelectionOptions.AllNodes}
-            label={t('Apply to all the nodes on the cluster')}
+            label={t('Apply to all the worker nodes on the cluster')}
             name="node-selection-radio-group"
             onChange={() => {
               setPolicy((draftPolicy) => {
@@ -66,7 +66,7 @@ const NodeSelectionRadioGroup: FC<NodeSelectionRadioGroupProps> = ({ policy, set
           <Radio
             id="node-selection-radio-select"
             isChecked={nodeSelectionOption === NodeSelectionOptions.SelectNodes}
-            label={t('Apply to specific subsets of Nodes using the Nodes selector')}
+            label={t('Apply to specific subsets of nodes using the node selector')}
             name="node-selection-radio-group"
             onChange={() => {
               setNodeSelectorOpen(true);

--- a/src/utils/components/PolicyForm/PolicyWizard/steps/ReviewStep/ReviewStep.tsx
+++ b/src/utils/components/PolicyForm/PolicyWizard/steps/ReviewStep/ReviewStep.tsx
@@ -22,10 +22,12 @@ import { SidebarEditorProvider } from '@utils/components/SidebarEditor/SidebarEd
 import SidebarEditorSwitch from '@utils/components/SidebarEditor/SidebarEditorSwitch';
 import { NO_DATA_DASH } from '@utils/constants';
 import { useNMStateTranslation } from '@utils/hooks/useNMStateTranslation';
-import { getMTU, getOVNBridgeName, getOVNLocalnet } from '@utils/resources/policies/selectors';
+import { getOVNBridgeName, getOVNLocalnet } from '@utils/resources/policies/selectors';
 import { getUplinkDisplayText } from '@utils/resources/policies/utils';
 
 import NodeNetworkConfigurationPolicyModel from '../../../../../../console-models/NodeNetworkConfigurationPolicyModel';
+
+import MTUDetailItem from './components/MTUDetailItem';
 
 import './ReviewStep.scss';
 
@@ -120,7 +122,7 @@ const ReviewStep: FC<ReviewStepProps> = ({
                 header={t('Bridge name')}
                 description={getOVNBridgeName(policy) || NO_DATA_DASH}
               />
-              <DetailItem header={t('MTU')} description={getMTU(policy) || NO_DATA_DASH} />
+              <MTUDetailItem policy={policy} />
             </DescriptionList>
           </StackItem>
           <StackItem isFilled />

--- a/src/utils/components/PolicyForm/PolicyWizard/steps/ReviewStep/components/MTUDetailItem.tsx
+++ b/src/utils/components/PolicyForm/PolicyWizard/steps/ReviewStep/components/MTUDetailItem.tsx
@@ -1,0 +1,43 @@
+import React, { FC } from 'react';
+
+import { V1NodeNetworkConfigurationPolicy } from '@kubevirt-ui/kubevirt-api/nmstate';
+import DetailItem from '@utils/components/DetailItem/DetailItem';
+import useInheritedMTU from '@utils/components/PolicyForm/PolicyWizard/utils/hooks/useInheritedMTU/useInheritedMTU';
+import { ConnectionOption } from '@utils/components/PolicyForm/PolicyWizard/utils/types';
+import { getUplinkConnectionOption } from '@utils/components/PolicyForm/PolicyWizard/utils/utils';
+import { NO_DATA_DASH } from '@utils/constants';
+import { useNMStateTranslation } from '@utils/hooks/useNMStateTranslation';
+import { getMTU } from '@utils/resources/policies/selectors';
+
+type MTUDetailItemProps = {
+  policy: V1NodeNetworkConfigurationPolicy;
+};
+
+const MTUDetailItem: FC<MTUDetailItemProps> = ({ policy }) => {
+  const { t } = useNMStateTranslation();
+  const inheritedMTU = useInheritedMTU(policy);
+  const explicitMTU = getMTU(policy);
+  const isBrex = getUplinkConnectionOption(policy) === ConnectionOption.BREX;
+
+  const hint = inheritedMTU ? (
+    <span className="pf-v6-u-text-color-subtle pf-v6-u-font-size-sm pf-v6-u-ml-sm">
+      {isBrex
+        ? t('({{inheritedMTU}} from existing bridge)', { inheritedMTU })
+        : t('({{inheritedMTU}} from uplink)', { inheritedMTU })}
+    </span>
+  ) : null;
+
+  return (
+    <DetailItem
+      header={t('MTU')}
+      description={
+        <>
+          {explicitMTU || NO_DATA_DASH}
+          {!explicitMTU && hint}
+        </>
+      }
+    />
+  );
+};
+
+export default MTUDetailItem;

--- a/src/utils/components/PolicyForm/PolicyWizard/steps/SettingsStep/SettingsStep.scss
+++ b/src/utils/components/PolicyForm/PolicyWizard/steps/SettingsStep/SettingsStep.scss
@@ -2,4 +2,8 @@
 
 .settings-step {
   width: vars.$nncp-wizard-step-width;
+
+  input[type='number'] {
+    max-width: 100%;
+  }
 }

--- a/src/utils/components/PolicyForm/PolicyWizard/steps/SettingsStep/SettingsStep.tsx
+++ b/src/utils/components/PolicyForm/PolicyWizard/steps/SettingsStep/SettingsStep.tsx
@@ -15,6 +15,7 @@ import FormGroupHelperText from '@utils/components/FormGroupHelperText/FormGroup
 import TextWithHelpIcon from '@utils/components/HelpTextIcon/TextWithHelpIcon';
 import { validateMTU } from '@utils/components/PolicyForm/PolicyWizard/steps/SettingsStep/utils/utils';
 import useBridgeNameValidation from '@utils/components/PolicyForm/PolicyWizard/utils/hooks/useBridgeNameValidation';
+import useInheritedMTU from '@utils/components/PolicyForm/PolicyWizard/utils/hooks/useInheritedMTU/useInheritedMTU';
 import { updateBridgeName } from '@utils/components/PolicyForm/PolicyWizard/utils/utils';
 import { useNMStateTranslation } from '@utils/hooks/useNMStateTranslation';
 import {
@@ -22,6 +23,8 @@ import {
   getInterfaceName,
   getMTU,
 } from '@utils/resources/policies/selectors';
+
+import { DEFAULT_MTU } from './utils/constants';
 
 import './SettingsStep.scss';
 
@@ -35,8 +38,10 @@ const SettingsStep: FC<ConfigurationStepProps> = ({ policy, setPolicy }) => {
   const [mtuValidationMessage, setMTUValidationMessage] = useState<string>('');
   const [nameValidationMessage, setNameValidationMessage] = useState<string>('');
   const validateName = useBridgeNameValidation(policy);
+  const inheritedMTU = useInheritedMTU(policy);
 
   const currentMTU = getMTU(policy);
+  const mtuPlaceholder = (inheritedMTU ?? DEFAULT_MTU).toString();
   const mtuValidation = mtuValidationMessage ? ValidatedOptions.error : ValidatedOptions.default;
   const nameValidation = nameValidationMessage ? ValidatedOptions.error : ValidatedOptions.default;
 
@@ -93,7 +98,7 @@ const SettingsStep: FC<ConfigurationStepProps> = ({ policy, setPolicy }) => {
               type="number"
               id="mtu"
               name="mtu"
-              placeholder={'1500'}
+              placeholder={mtuPlaceholder}
               validated={mtuValidation}
               value={currentMTU}
               onChange={(_, newMTU) => handleMTUChange(newMTU)}

--- a/src/utils/components/PolicyForm/PolicyWizard/steps/UplinkConnectionStep/components/BondingInterfaceContent/BondingInterfaceContent.tsx
+++ b/src/utils/components/PolicyForm/PolicyWizard/steps/UplinkConnectionStep/components/BondingInterfaceContent/BondingInterfaceContent.tsx
@@ -70,6 +70,7 @@ const BondingInterfaceContent: FC<BondingInterfaceContentProps> = ({
               text={t('Network interfaces')}
             />
           }
+          isRequired
           fieldId="bonding-port"
         >
           <NetworkInterfacesSelect policy={policy} setPolicy={setPolicy} />

--- a/src/utils/components/PolicyForm/PolicyWizard/utils/hooks/useInheritedMTU/useInheritedMTU.ts
+++ b/src/utils/components/PolicyForm/PolicyWizard/utils/hooks/useInheritedMTU/useInheritedMTU.ts
@@ -1,0 +1,24 @@
+import { V1NodeNetworkConfigurationPolicy } from '@kubevirt-ui/kubevirt-api/nmstate';
+import { ConnectionOption } from '@utils/components/PolicyForm/PolicyWizard/utils/types';
+import { getUplinkConnectionOption } from '@utils/components/PolicyForm/PolicyWizard/utils/utils';
+import { getNodeSelector } from '@utils/resources/policies/getters';
+
+import useNodeInterfaces from '../useNodeInterfaces/useNodeInterfaces';
+
+import { getBrExMTU, getSelectedUplinkPortNames, getUplinkMTU } from './utils';
+
+const useInheritedMTU = (policy: V1NodeNetworkConfigurationPolicy): number | undefined => {
+  const { availableInterfaces, selectedNodeNNSResources } = useNodeInterfaces(
+    getNodeSelector(policy),
+  );
+
+  if (getUplinkConnectionOption(policy) === ConnectionOption.BREX) {
+    return getBrExMTU(selectedNodeNNSResources);
+  }
+
+  const portNames = getSelectedUplinkPortNames(policy);
+
+  return portNames.length > 0 ? getUplinkMTU(portNames, availableInterfaces) : undefined;
+};
+
+export default useInheritedMTU;

--- a/src/utils/components/PolicyForm/PolicyWizard/utils/hooks/useInheritedMTU/utils.ts
+++ b/src/utils/components/PolicyForm/PolicyWizard/utils/hooks/useInheritedMTU/utils.ts
@@ -1,0 +1,62 @@
+import {
+  InterfaceType,
+  NodeNetworkConfigurationInterface,
+  V1beta1NodeNetworkState,
+  V1NodeNetworkConfigurationPolicy,
+} from '@kubevirt-ui/kubevirt-api/nmstate';
+import {
+  DEFAULT_OVN_BRIDGE_NAME,
+  DEFAULT_OVS_INTERFACE_NAME,
+} from '@utils/components/PolicyForm/PolicyWizard/utils/constants';
+import { ConnectionOption } from '@utils/components/PolicyForm/PolicyWizard/utils/types';
+import { getUplinkConnectionOption } from '@utils/components/PolicyForm/PolicyWizard/utils/utils';
+import { getInterfaces } from '@utils/resources/nns/getters';
+import { getBondPortNames, getBridgePorts } from '@utils/resources/policies/selectors';
+
+const getValidMTUs = (mtus: (number | undefined)[]): number[] =>
+  mtus.filter((mtu): mtu is number => mtu != null);
+
+const minMTU = (mtus: number[]): number | undefined =>
+  mtus.length > 0 ? Math.min(...mtus) : undefined;
+
+export const getBrExMTU = (nodeNetworkStates: V1beta1NodeNetworkState[]): number | undefined => {
+  const mtus = getValidMTUs(
+    nodeNetworkStates?.map((nns) => {
+      const brExInterface = getInterfaces(nns)?.find(
+        (iface) =>
+          iface?.name === DEFAULT_OVN_BRIDGE_NAME && iface?.type === InterfaceType.OVS_INTERFACE,
+      );
+      return brExInterface?.mtu;
+    }),
+  );
+
+  return minMTU(mtus);
+};
+
+export const getSelectedUplinkPortNames = (policy: V1NodeNetworkConfigurationPolicy): string[] => {
+  const connectionOption = getUplinkConnectionOption(policy);
+
+  if (connectionOption === ConnectionOption.SINGLE_DEVICE) {
+    const portName = getBridgePorts(policy)?.filter(
+      (port) => port.name !== DEFAULT_OVS_INTERFACE_NAME,
+    )?.[0]?.name;
+    return portName ? [portName] : [];
+  }
+
+  if (connectionOption === ConnectionOption.BONDING_INTERFACE) {
+    return getBondPortNames(policy) || [];
+  }
+
+  return [];
+};
+
+export const getUplinkMTU = (
+  portNames: string[],
+  availableInterfaces: NodeNetworkConfigurationInterface[],
+): number | undefined => {
+  const mtus = getValidMTUs(
+    portNames.map((name) => availableInterfaces?.find((iface) => iface.name === name)?.mtu),
+  );
+
+  return minMTU(mtus);
+};

--- a/src/utils/components/PolicyForm/PolicyWizard/utils/hooks/useNodeInterfaces/useNodeInterfaces.ts
+++ b/src/utils/components/PolicyForm/PolicyWizard/utils/hooks/useNodeInterfaces/useNodeInterfaces.ts
@@ -36,7 +36,12 @@ const useNodeInterfaces: UseNodeInterfaces = (nodeSelector) => {
   const availableInterfaces = getAvailableInterfacesForNodes(selectedNodeNNSResources);
   const existingInterfaceNames = getExistingInterfaceNames(nnsResources);
 
-  return { availableInterfaces, existingInterfaceNames, loaded: nnsLoaded && data?.nodes?.loaded };
+  return {
+    availableInterfaces,
+    existingInterfaceNames,
+    loaded: nnsLoaded && data?.nodes?.loaded,
+    selectedNodeNNSResources,
+  };
 };
 
 export default useNodeInterfaces;

--- a/src/utils/components/PolicyForm/PolicyWizard/utils/hooks/useNodeInterfaces/utils/types.ts
+++ b/src/utils/components/PolicyForm/PolicyWizard/utils/hooks/useNodeInterfaces/utils/types.ts
@@ -13,4 +13,5 @@ export type NodeInterfacesData = {
   availableInterfaces: NodeNetworkConfigurationInterface[];
   existingInterfaceNames: string[];
   loaded: boolean;
+  selectedNodeNNSResources: V1beta1NodeNetworkState[];
 };

--- a/src/views/nodenetworkconfiguration/components/TopologySidebar/InterfaceDrawer/TopologyDrawer.tsx
+++ b/src/views/nodenetworkconfiguration/components/TopologySidebar/InterfaceDrawer/TopologyDrawer.tsx
@@ -1,21 +1,24 @@
 import React, { FC, ReactNode, useState } from 'react';
-import { useNMStateTranslation } from 'src/utils/hooks/useNMStateTranslation';
 import { useNavigate } from 'react-router-dom-v5-compat';
+import { useLocation } from 'react-router-dom-v5-compat';
+import { useNMStateTranslation } from 'src/utils/hooks/useNMStateTranslation';
+
+import { V1beta1NodeNetworkState } from '@kubevirt-ui/kubevirt-api/nmstate';
 import {
+  Alert,
+  AlertActionCloseButton,
+  AlertVariant,
   Drawer,
   DrawerContent,
   DrawerContentBody,
-  DrawerPanelContent,
   DrawerPanelBody,
-  Alert,
-  AlertVariant,
-  AlertActionCloseButton,
+  DrawerPanelContent,
 } from '@patternfly/react-core';
-import '.././TopologySidebar.scss';
-import CustomDrawer from '../CustomDrawer';
-import { V1beta1NodeNetworkState } from '@kubevirt-ui/kubevirt-api/nmstate';
-import { useLocation } from 'react-router-dom-v5-compat';
+
 import { CREATE_POLICY_QUERY_PARAM } from '../constants';
+import CustomDrawer from '../CustomDrawer';
+
+import '.././TopologySidebar.scss';
 
 type Props = {
   states: V1beta1NodeNetworkState[];
@@ -46,7 +49,6 @@ const TopologyDrawer: FC<Props> = ({ states, children }) => {
             isResizable
             defaultSize="1200px"
             minSize="150px"
-            maxSize="1200px"
             role="dialog"
             aria-label={t('Topology side panel')}
             className="drawerPanelContent"


### PR DESCRIPTION
Shows default MTU info in NNCP form: Review step and Settings step MTU placeholder

Other fixes to NNCP form:

- disables further steps if uplink is not selected
- input for MTU has full width
- make drawer panel resizable

Before:

https://github.com/user-attachments/assets/9047beac-95a7-4949-8f09-23abe0cadca2


After:

https://github.com/user-attachments/assets/3c6a8673-ecf9-472b-9912-b077f9b47b6e



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added inherited MTU (Maximum Transmission Unit) display in policy settings and review screens.

* **Improvements**
  * Enhanced form validation for uplink connection settings, disabling subsequent steps when settings are invalid.
  * Refined node selection terminology and marked network interface configuration as required.

* **Localization**
  * Updated UI text across multiple languages with improved wording and clarity for policy configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->