### PR TITLE
fix(deps): CVE transitive dependency remediation (release-4.23)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17465,15 +17465,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -18238,6 +18229,7 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -18447,9 +18439,9 @@
       }
     },
     "node_modules/sass/node_modules/immutable": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.5.tgz",
-      "integrity": "sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==",
+      "version": "4.3.8",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.8.tgz",
+      "integrity": "sha512-d/Ld9aLbKpNwyl0KiM2CT1WYvkitQ1TSvmRtkcV8FKStiDoA7Slzgjmb/1G2yhKM1p0XeNOieaTbFZmU1d3Xuw==",
       "dev": true,
       "license": "MIT"
     },
@@ -18624,12 +18616,12 @@
       "license": "MIT"
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
       "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/serve-index": {
@@ -23252,8 +23244,8 @@
       "dev": true,
       "requires": {
         "@patternfly/react-topology": "^6.2.0",
-        "immutable": "3.x",
-        "lodash": "^4.17.21",
+        "immutable": "3.8.3",
+        "lodash": "4.18.1",
         "react": "^17.0.1",
         "react-i18next": "^11.12.0",
         "react-redux": "7.2.9",
@@ -23273,7 +23265,7 @@
       "dev": true,
       "requires": {
         "@patternfly/react-topology": "^6.2.0",
-        "immutable": "3.x",
+        "immutable": "3.8.3",
         "react": "^17.0.1",
         "react-i18next": "^11.12.0",
         "react-redux": "7.2.9",
@@ -23296,7 +23288,7 @@
         "comment-json": "4.x",
         "find-up": "4.x",
         "glob": "7.x",
-        "lodash": "^4.17.21",
+        "lodash": "4.18.1",
         "read-pkg": "5.x",
         "semver": "6.x",
         "webpack": "^5.75.0"
@@ -23308,7 +23300,7 @@
       "integrity": "sha512-+azUBN6FgcDmlcWMzG0bthcRUJC1u12wf9xa2aJGFbC/uTiOXwjrkcQ7LW/PyK5Em7wDhwaUdapaeOgh8I6Kjg==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.21",
+        "lodash": "4.18.1",
         "semver": "^7.3.7",
         "uuid": "^8.3.2",
         "yup": "^0.32.11"
@@ -23328,7 +23320,7 @@
       "integrity": "sha512-Pkq6R+fkoE0llgv9WJBcotViAPywrzDkpWK0HSTmrVyfEuWS5cuZUs8ono6L5w9BqDBRXm3ceEuUAZA/Zrar1w==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.21",
+        "lodash": "4.18.1",
         "semver": "^7.3.7",
         "yup": "^0.32.11"
       },
@@ -23507,7 +23499,7 @@
         "@patternfly/react-icons": "^6.4.0",
         "@patternfly/react-styles": "^6.4.0",
         "@patternfly/react-tokens": "^6.4.0",
-        "lodash": "^4.17.21",
+        "lodash": "4.18.1",
         "tslib": "^2.8.1"
       }
     },
@@ -23769,7 +23761,7 @@
         "chalk": "^3.0.0",
         "css.escape": "^1.5.1",
         "dom-accessibility-api": "^0.5.6",
-        "lodash": "^4.17.15",
+        "lodash": "4.18.1",
         "redent": "^3.0.0"
       },
       "dependencies": {
@@ -26316,7 +26308,7 @@
         "globby": "^14.0.0",
         "normalize-path": "^3.0.0",
         "schema-utils": "^4.2.0",
-        "serialize-javascript": "^6.0.2"
+        "serialize-javascript": "7.0.5"
       },
       "dependencies": {
         "globby": {
@@ -26520,7 +26512,7 @@
         "is-installed-globally": "~0.4.0",
         "lazy-ass": "^1.6.0",
         "listr2": "^3.8.3",
-        "lodash": "^4.17.21",
+        "lodash": "4.18.1",
         "log-symbols": "^4.0.0",
         "minimist": "^1.2.8",
         "ospath": "^1.2.2",
@@ -32473,7 +32465,7 @@
         "log-symbols": "^4.1.0",
         "minimatch": "^5.1.6",
         "ms": "^2.1.3",
-        "serialize-javascript": "^6.0.2",
+        "serialize-javascript": "7.0.5",
         "strip-json-comments": "^3.1.1",
         "supports-color": "^8.1.1",
         "workerpool": "^6.5.1",
@@ -33456,14 +33448,6 @@
         }
       }
     },
-    "randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "requires": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -33991,7 +33975,8 @@
     "safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true
     },
     "safe-push-apply": {
       "version": "1.0.0",
@@ -34036,7 +34021,7 @@
       "requires": {
         "@parcel/watcher": "2.5.1",
         "chokidar": "^4.0.0",
-        "immutable": "^5.0.2",
+        "immutable": "4.3.8",
         "source-map-js": ">=0.6.2 <2.0.0"
       },
       "dependencies": {
@@ -34090,9 +34075,9 @@
           "optional": true
         },
         "immutable": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.5.tgz",
-          "integrity": "sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==",
+          "version": "4.3.8",
+          "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.8.tgz",
+          "integrity": "sha512-d/Ld9aLbKpNwyl0KiM2CT1WYvkitQ1TSvmRtkcV8FKStiDoA7Slzgjmb/1G2yhKM1p0XeNOieaTbFZmU1d3Xuw==",
           "dev": true
         },
         "readdirp": {
@@ -34237,12 +34222,9 @@
       }
     },
     "serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
-      "requires": {
-        "randombytes": "^2.1.0"
-      }
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw=="
     },
     "serve-index": {
       "version": "1.9.2",
@@ -36379,8 +36361,8 @@
       "requires": {
         "@babel/runtime": "^7.15.4",
         "@types/lodash": "^4.14.175",
-        "lodash": "^4.17.21",
-        "lodash-es": "^4.17.21",
+        "lodash": "4.18.1",
+        "lodash-es": "4.18.1",
         "nanoclone": "^0.2.1",
         "property-expr": "^2.0.4",
         "toposort": "^2.0.2"

--- a/package.json
+++ b/package.json
@@ -101,6 +101,19 @@
   },
   "overrides": {
     "@parcel/watcher": "2.5.1",
-    "qs": "6.14.2"
+    "qs": "6.14.2",
+    "lodash": "4.18.1",
+    "lodash-es": "4.18.1",
+    "serialize-javascript": "7.0.5",
+    "node-forge": "1.4.0",
+    "@openshift-console/dynamic-plugin-sdk": {
+      "immutable": "3.8.3"
+    },
+    "@openshift-console/dynamic-plugin-sdk-internal": {
+      "immutable": "3.8.3"
+    },
+    "sass": {
+      "immutable": "4.3.8"
+    }
   }
 }


### PR DESCRIPTION
### CVE dependency remediation

Pins transitive **lodash** / **lodash-es**, **serialize-javascript**, **node-forge**, **qs**, and **immutable** (OpenShift console SDK vs **sass**) using npm **overrides** on `main` and `release-4.22`+ and yarn **resolutions** on `release-4.16` through `release-4.21`, addressing OCPBUGS-tracked findings for the networking console plugin.

### Companion PRs

| Base branch | Pull request |
|-------------|--------------|
| main | https://github.com/openshift/nmstate-console-plugin/pull/197 |
| release-4.23 | https://github.com/openshift/nmstate-console-plugin/pull/198 |
| release-4.22 | https://github.com/openshift/nmstate-console-plugin/pull/199 |
| release-4.21 | https://github.com/openshift/nmstate-console-plugin/pull/200 |
| release-4.20 | https://github.com/openshift/nmstate-console-plugin/pull/201 |
| release-4.19 | https://github.com/openshift/nmstate-console-plugin/pull/202 |
| release-4.18 | https://github.com/openshift/nmstate-console-plugin/pull/203 |
| release-4.17 | https://github.com/openshift/nmstate-console-plugin/pull/204 |
| release-4.16 | https://github.com/openshift/nmstate-console-plugin/pull/205 |
