### PR TITLE
OCPBUGS-83806: Add Physical networks page to virtualization perspective

### DIFF
--- a/src/views/physical-networks/manifest.ts
+++ b/src/views/physical-networks/manifest.ts
@@ -15,6 +15,26 @@ export const PhysicalNetworksExtensions: EncodedExtension[] = [
     },
     properties: {
       dataAttributes: {
+        'data-quickstart-id': 'qs-nav-physical-networks-virt-perspective',
+        'data-test-id': 'physical-networks-virt-perspective-nav-item',
+      },
+      href: '/physical-networks',
+      id: 'physical-networks-virt-perspective',
+      insertBefore: 'networkpolicies-virt-perspective',
+      name: '%plugin__nmstate-console-plugin~Physical networks%',
+      prefixNamespaced: false,
+      section: 'networking-virt-perspective',
+      perspective: 'virtualization-perspective',
+      insertAfter: ['udns-virt-perspective', 'node-network-configuration-virt-perspective'],
+    },
+    type: 'console.navigation/href',
+  } as EncodedExtension<HrefNavItem>,
+  {
+    flags: {
+      required: ['NMSTATE_DYNAMIC'],
+    },
+    properties: {
+      dataAttributes: {
         'data-quickstart-id': 'qs-nav-physical-networks',
         'data-test-id': 'physical-networks-nav-item',
       },


### PR DESCRIPTION
This bug adds the Physicals networks page to the Virtualization perspective.

Jira: https://redhat.atlassian.net/browse/OCPBUGS-83806

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new navigation entry in the virtualization perspective for accessing Physical Networks, providing quick access from the virtualization menu and integrated alongside existing virtualization items.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->