### PR TITLE
CNV-83133: fix Node network configuration page path (cherry-pick #196 to release-4.22)

### DIFF
--- a/src/views/physical-networks/utils/constants.ts
+++ b/src/views/physical-networks/utils/constants.ts
@@ -4,6 +4,6 @@ export const DEFAULT_OVN_BRIDGE_NAME = 'br-ex';
 export const OVN_BRIDGE_MAPPINGS = 'bridge-mappings';
 
 export const NODE_NETWORK_CONFIGURATION_WIZARD_PATH =
-  'node-network-configuration?createPolicy=true';
+  '/node-network-configuration?createPolicy=true';
 
 export const PHYSICAL_NETWORK_NAME_PARAM_KEY = 'physicalNetworkName';


### PR DESCRIPTION
## Summary
- Cherry-pick of #196 to `release-4.22` branch
- Fixes a missing leading `/` in the `NODE_NETWORK_CONFIGURATION_WIZARD_PATH` constant, which caused broken navigation when navigating from the Physical networks page to the Node network configuration wizard

## Related
- Jira: https://redhat.atlassian.net/browse/CNV-83133
- Original PR: https://github.com/openshift/nmstate-console-plugin/pull/196


Made with [Cursor](https://cursor.com)