### PR TITLE
OCPBUGS-77435: Guard against errors when no Nodes are selected

### DIFF
--- a/src/utils/components/PolicyForm/PolicyWizard/utils/hooks/useNodeInterfaces/utils/utils.ts
+++ b/src/utils/components/PolicyForm/PolicyWizard/utils/hooks/useNodeInterfaces/utils/utils.ts
@@ -4,6 +4,7 @@ import {
   NodeNetworkConfigurationInterface,
   V1beta1NodeNetworkState,
 } from '@kubevirt-ui/kubevirt-api/nmstate';
+import { isEmpty } from '@utils/helpers';
 import { getInterfaces } from '@utils/resources/nns/getters';
 import { getEthernetInterfaces } from '@utils/resources/nns/utils';
 
@@ -46,6 +47,8 @@ const nnsInterfaceComparator = (
 ) => ifaceA.name === ifaceB.name;
 
 export const getAvailableInterfacesForNodes = (nodeNetworkStates: V1beta1NodeNetworkState[]) => {
-  const portsByNode = nodeNetworkStates.map((nns) => getAvailableInterfacesForNode(nns));
+  if (isEmpty(nodeNetworkStates)) return [];
+
+  const portsByNode = nodeNetworkStates?.map((nns) => getAvailableInterfacesForNode(nns));
   return intersectionWith(...portsByNode, nnsInterfaceComparator);
 };


### PR DESCRIPTION
This PR adds a guard against errors when no Nodes are selected in the "Nodes configuration" step of the Node network configuration wizard. 

**Root cause**: If no nodes were selected an empty array was passed to the `intersectionWith` lodash function which treats all but the last argument (the comparator function) as an array of arrays which it then spreads. Because the array was empty lodash would attempt to iterate over the comparator function which isn't interable. This would lead to a `TypeError: n is not iterable` error.

Jira: https://redhat.atlassian.net/browse/OCPBUGS-77435