### PR TITLE
OCPBUGS-83807: Fix issues in NodeNetworkConfiguration topology view

### DIFF
--- a/cypress/e2e/NewPolicy.spec.cy.ts
+++ b/cypress/e2e/NewPolicy.spec.cy.ts
@@ -49,7 +49,8 @@ describe('Create new policy with form', () => {
     cy.byLegacyTestID('review-network-description').should('have.text', testDescription);
     cy.contains('button', 'Create network').click();
 
-    cy.contains('h1', testPolicyName);
+    cy.visit('/k8s/cluster/nmstate.io~v1~NodeNetworkConfigurationPolicy');
+    cy.contains('a', testPolicyName);
 
     deletePolicyFromDetailsPage(testPolicyName);
   });

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -8,3 +8,6 @@ export const NODE_HOSTNAME_LABEL = 'kubernetes.io/hostname';
 export const NO_DATA_DASH = '-';
 
 export const NMSTATE_I18N_NS = 'plugin__nmstate-console-plugin';
+
+export const LINK_AGGREGATION = 'link-aggregation';
+export const BASE_IFACE = 'base-iface';

--- a/src/views/nodenetworkconfiguration/utils/constants.ts
+++ b/src/views/nodenetworkconfiguration/utils/constants.ts
@@ -7,3 +7,7 @@ export const GROUP = 'group';
 export const TOPOLOGY_LOCAL_STORAGE_KEY = 'topologyNodePositions';
 export const NODE_POSITIONING_EVENT = 'node-positioned';
 export const GRAPH_POSITIONING_EVENT = 'graph-position-change';
+
+export const OVN_K8S_MP0 = 'ovn-k8s-mp0';
+export const BR_INT = 'br-int';
+export const GENEV_SYS_PREFIX = 'genev_sys_';

--- a/src/views/nodenetworkconfiguration/utils/utils.ts
+++ b/src/views/nodenetworkconfiguration/utils/utils.ts
@@ -14,11 +14,12 @@ import {
   NodeShape,
   NodeStatus,
 } from '@patternfly/react-topology';
+import { BASE_IFACE, LINK_AGGREGATION } from '@utils/constants';
 import { isEmpty } from '@utils/helpers';
 
 import BridgeIcon from '../components/BridgeIcon';
 
-import { GROUP, NODE_DIAMETER } from './constants';
+import { BR_INT, GENEV_SYS_PREFIX, GROUP, NODE_DIAMETER, OVN_K8S_MP0 } from './constants';
 
 const statusMap: { [key: string]: NodeStatus } = {
   up: NodeStatus.success,
@@ -27,10 +28,13 @@ const statusMap: { [key: string]: NodeStatus } = {
 };
 
 const networkTypeLevelMap = {
+  [InterfaceType.OVS_INTERFACE]: 1,
+  [InterfaceType.OVS_BRIDGE]: 2,
   [InterfaceType.LINUX_BRIDGE]: 2,
   [InterfaceType.VLAN]: 3,
   [InterfaceType.BOND]: 4,
   [InterfaceType.ETHERNET]: 5,
+  [InterfaceType.INFINIBAND]: 5,
 };
 
 export const networkNodeLevel = new Proxy(networkTypeLevelMap, {
@@ -58,25 +62,30 @@ const getIcon = (iface: NodeNetworkConfigurationInterface) => {
 const createNodes = (
   nnsName: string,
   interfaces: NodeNetworkConfigurationInterface[],
-  nnceConfigredInterfaces: NodeNetworkConfigurationInterface[],
+  nnceConfiguredInterfaces: NodeNetworkConfigurationInterface[],
 ): NodeModel[] =>
   interfaces.map((iface) => {
-    const isDerivedFromPolicy = findInterfaceByName(nnceConfigredInterfaces, iface.name);
+    const isDerivedFromPolicy = findInterfaceByName(nnceConfiguredInterfaces, iface.name);
     return {
       id: `${nnsName}~${iface.name}~${iface.type}`,
       type: ModelKind.node,
       label: iface.name,
       width: NODE_DIAMETER,
       height: NODE_DIAMETER,
-      visible: !iface.patch && iface.type !== InterfaceType.LOOPBACK,
+      visible:
+        !iface.patch &&
+        iface.type !== InterfaceType.LOOPBACK &&
+        iface.name !== OVN_K8S_MP0 &&
+        iface.name !== BR_INT &&
+        !iface.name.startsWith(GENEV_SYS_PREFIX),
       shape: isDerivedFromPolicy ? NodeShape.circle : NodeShape.rect,
       status: getStatus(iface),
       data: {
         icon: getIcon(iface),
         type: iface.type,
         bridgePorts: iface.bridge?.port,
-        bondPorts: iface['link-aggregation']?.port,
-        vlanBaseInterface: iface.vlan?.['base-iface'],
+        bondPorts: iface[LINK_AGGREGATION]?.port,
+        vlanBaseInterface: iface.vlan?.[BASE_IFACE],
         level: networkNodeLevel[iface.type],
         isDerivedFromPolicy,
       },

--- a/src/views/policies/list/components/CreatePolicyButtons.tsx
+++ b/src/views/policies/list/components/CreatePolicyButtons.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { FC, ReactNode } from 'react';
 import { useNavigate } from 'react-router';
 import NodeNetworkConfigurationPolicyModel, {
   NodeNetworkConfigurationPolicyModelRef,
@@ -10,7 +10,11 @@ import { useNMStateTranslation } from '@utils/hooks/useNMStateTranslation';
 import { NNCP_YAML_EDITOR_OPENED } from '@utils/telemetry/constants';
 import { logNMStateEvent } from '@utils/telemetry/telemetry';
 
-const CreatePolicyButtons: FC = ({ children }) => {
+type CreatePolicyButtonsProps = {
+  children: ReactNode;
+};
+
+const CreatePolicyButtons: FC<CreatePolicyButtonsProps> = ({ children }) => {
   const { t } = useNMStateTranslation();
   const navigate = useNavigate();
 


### PR DESCRIPTION
This PR makes the following changes to the NodeNetworkConfiguration topology view.

- Position `ovs-interface` interfaces above `ovs-bridge` interfaces
- Position `infiniband` interfaces at the bottom-most level next to `ethernet` interfaces
- Position `ovs-bridge` interfaces on the same level as `linux-bridge` interfaces
- Hide the following interfaces:
-- `ovn-k8s-mp0`
-- Interfaces starting with `genev-sys`
-- `br-int`

Jira: https://redhat.atlassian.net/browse/OCPBUGS-83807

## Screenshots

### Before

<img width="1596" height="1104" alt="topology-view--BEFORE--2026-05-13-220856" src="https://github.com/user-attachments/assets/50470b59-1a80-4b51-ab9a-31b5f611450e" />

### After

<img width="1478" height="1026" alt="topology-view--AFTER--2026-05-13-220137" src="https://github.com/user-attachments/assets/0524fcf7-aad0-4a88-92c1-911923ae833d" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved network topology rendering to recognize more interface types and hide internal/auxiliary interfaces for clearer node views.
  * Standardized interface configuration handling to ensure more reliable display of bonded and VLAN relationships.
* **Tests**
  * Updated end-to-end test flow to confirm newly created policies appear in the policies listing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->