### PR TITLE
OCPBUGS-88031: Fix CVE-2026-6322

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9424,9 +9424,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",
@@ -24616,7 +24616,7 @@
           "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
           "requires": {
             "fast-deep-equal": "^3.1.3",
-            "fast-uri": "^3.0.1",
+            "fast-uri": "3.1.2",
             "json-schema-traverse": "^1.0.0",
             "require-from-string": "^2.0.2"
           }
@@ -27720,9 +27720,9 @@
       "dev": true
     },
     "fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ=="
     },
     "fastest-levenshtein": {
       "version": "1.0.16",
@@ -33475,7 +33475,7 @@
           "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
           "requires": {
             "fast-deep-equal": "^3.1.3",
-            "fast-uri": "^3.0.1",
+            "fast-uri": "3.1.2",
             "json-schema-traverse": "^1.0.0",
             "require-from-string": "^2.0.2"
           }

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
   },
   "overrides": {
     "@parcel/watcher": "2.5.1",
-    "qs": "6.14.2"
+    "qs": "6.14.2",
+    "fast-uri": "3.1.2"
   }
 }


### PR DESCRIPTION
Override fast-uri version to 3.1.2 to address CVE-2026-6322.

Jira: https://redhat.atlassian.net/browse/OCPBUGS-88031

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package dependency overrides to maintain stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->