### PR TITLE
OCPBUGS-94054: Upgrade fast-uri to v3.1.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9424,9 +9424,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
+      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
       "funding": [
         {
           "type": "github",
@@ -24616,7 +24616,7 @@
           "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
           "requires": {
             "fast-deep-equal": "^3.1.3",
-            "fast-uri": "3.1.2",
+            "fast-uri": "3.1.3",
             "json-schema-traverse": "^1.0.0",
             "require-from-string": "^2.0.2"
           }
@@ -27720,9 +27720,9 @@
       "dev": true
     },
     "fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ=="
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
+      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg=="
     },
     "fastest-levenshtein": {
       "version": "1.0.16",
@@ -33475,7 +33475,7 @@
           "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
           "requires": {
             "fast-deep-equal": "^3.1.3",
-            "fast-uri": "3.1.2",
+            "fast-uri": "3.1.3",
             "json-schema-traverse": "^1.0.0",
             "require-from-string": "^2.0.2"
           }

--- a/package.json
+++ b/package.json
@@ -101,6 +101,6 @@
   "overrides": {
     "@parcel/watcher": "2.5.1",
     "qs": "6.14.2",
-    "fast-uri": "3.1.2"
+    "fast-uri": "3.1.3"
   }
 }


### PR DESCRIPTION
Upgrade fast-uri to v3.1.3 to fix CVE-2026-13676.

Jira: https://redhat.atlassian.net/browse/OCPBUGS-94054

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a bundled package resolution to a newer patch version for improved reliability and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->