### PR TITLE
OPNET-796: test: suppress xtrace when exporting CI secrets

### DIFF
--- a/test-prow-e2e.sh
+++ b/test-prow-e2e.sh
@@ -148,7 +148,10 @@ until \
 
 INSTALLER_DIR=${INSTALLER_DIR:=${ARTIFACT_DIR}/installer}
 
+# Suppress xtrace while exporting secrets to avoid leaking them in CI logs.
+set +x
 export CYPRESS_KUBEADMIN_PASSWORD="$(cat "${KUBEADMIN_PASSWORD_FILE:-${INSTALLER_DIR}/auth/kubeadmin-password}")"
+set -x
 export BRIDGE_BASE_ADDRESS="$(oc get consoles.config.openshift.io cluster -o jsonpath='{.status.consoleURL}')"
 
 # Disable color codes in Cypress since they do not render well CI test logs.


### PR DESCRIPTION
Disable bash xtrace (`set +x`) around the `CYPRESS_KUBEADMIN_PASSWORD` export
in `test-prow-e2e.sh` to prevent the password value from appearing in CI build
logs via xtrace expansion. Re-enable xtrace (`set -x`) immediately after.

The script has `set -eExuo pipefail` at line 3, which enables xtrace globally.
When `CYPRESS_KUBEADMIN_PASSWORD` is exported via command substitution, xtrace
echoes the expanded value to stderr, which Prow captures into the build log.

While the credential is for an ephemeral CI cluster (torn down after the job)
and the ci-operator sidecar censors SHARED_DIR file contents, this change avoids
relying solely on external log scrubbing.

---
🤖 *This PR was generated by AI on behalf of @mkowalski, who has reviewed it.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Improved CI log protection by preventing the kubeadmin password from appearing in shell trace output during test setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->