### PR TITLE
fix: use electron browser in cypress [release-4.19]

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "serve-build": "yarn build && npx http-server -p 9001 dist",
     "dev": "yarn webpack serve",
     "start-console": "./start-console.sh",
-    "cypress": "cypress run --browser chrome",
+    "cypress": "cypress run --browser electron",
     "cypress:open": "cypress open",
     "i18n": "i18next \"src/**/*.{js,jsx,ts,tsx}\" [-oc] -c i18next-parser.config.mjs",
     "lint": "eslint .",


### PR DESCRIPTION
## Summary

- Change `cypress run --browser chrome` → `cypress run --browser electron` in `package.json`

## Why this branch is broken

`test-prow-e2e.sh` on `release-4.19` calls `yarn run cypress`, which maps directly to the `cypress` npm script. That script was passing `--browser chrome`, but `tectonic-console-builder-v29` (the current CI builder for this branch) does not ship Chrome — only Electron is bundled with Cypress.

Failing Prow run: https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_nmstate-console-plugin/245/pull-ci-openshift-nmstate-console-plugin-release-4.19-e2e-tests/2077793896619839488

```
Browser: chrome was not found on your system or is not supported by Cypress.
Available browsers found on your system are:
 - electron
```

## Root cause

openshift/release#78488 (networking-console-plugin yarn→npm migration) accidentally bumped the CI builder for `nmstate-console-plugin release-4.19` from `tectonic-console-builder-v24` (which ships Chrome) to `v29` (which does not). `nmstate-console-plugin` was never part of that migration.

Rather than reverting, this PR fixes the `cypress` script to use `electron`, which is always bundled with Cypress and uses the same Chromium engine.

## Companion PRs

**CI builder standardization** (openshift/release): openshift/release#82053
Bumps remaining branches (`release-4.17`, `release-4.18`, `release-4.20`) from v24 → v29.

**This series** (all branches):
| Branch | PR | Role |
|---|---|---|
| `release-4.19` | openshift/nmstate-console-plugin#263 | **Urgent** — fixes active CI failure |
| `release-4.21` | openshift/nmstate-console-plugin#264 | Consistency — CI already uses electron |
| `release-4.22` | openshift/nmstate-console-plugin#265 | Consistency — CI already uses electron |
| `main` | openshift/nmstate-console-plugin#266 | Consistency — CI already uses electron |
| `release-4.20` | openshift/nmstate-console-plugin#267 | **Prerequisite** — must merge before openshift/release#82053 |
| `release-4.18` | openshift/nmstate-console-plugin#268 | **Prerequisite** — must merge before openshift/release#82053 |
| `release-4.17` | openshift/nmstate-console-plugin#269 | **Prerequisite** — must merge before openshift/release#82053 |

## Test plan

- [ ] Prow e2e job passes on `release-4.19`

🤖 Generated with [Claude Code](https://claude.com/claude-code)