### PR TITLE
fix: use electron browser in cypress [release-4.22]

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "dev": "npm run webpack serve",
     "webpack": "webpack",
     "start-console": "./start-console.sh",
-    "cypress": "cypress run --browser chrome",
+    "cypress": "cypress run --browser electron",
     "cypress:open": "cypress open",
     "i18n": "i18next \"src/**/*.{js,jsx,ts,tsx}\" [-oc] -c i18next-parser.config.js && node ./i18n-scripts/set-english-defaults.js",
     "lint": "eslint .",


### PR DESCRIPTION
## Summary

- Change `cypress run --browser chrome` → `cypress run --browser electron` in `package.json` (developer consistency fix)

## Why CI is not broken on this branch

On `release-4.22`, `test-prow-e2e.sh` calls `npm run test-cypress-headless` — not `yarn run cypress`. The `test-cypress-headless` script already defaults to `electron`:

```
node ... cypress run --env openshift=true --browser ${BRIDGE_E2E_BROWSER_NAME:=electron}
```

So the CI pipeline on this branch is **not affected** by the Chrome absence in `tectonic-console-builder-v29`.

## Why this PR is still useful

The `cypress` script (used for local development: `yarn/npm run cypress`) still hardcodes `--browser chrome`, which will fail on any machine without Chrome. This PR makes the local developer experience consistent with what CI actually runs.

## Companion PRs

**CI builder standardization** (openshift/release): openshift/release#82053

**This series** (all branches):
| Branch | PR | Role |
|---|---|---|
| `release-4.19` | openshift/nmstate-console-plugin#263 | **Urgent** — fixes active CI failure |
| `release-4.21` | openshift/nmstate-console-plugin#264 | Consistency — CI already uses electron |
| `release-4.22` | openshift/nmstate-console-plugin#265 | Consistency — CI already uses electron |
| `main` | openshift/nmstate-console-plugin#266 | Consistency — CI already uses electron |
| `release-4.20` | openshift/nmstate-console-plugin#267 | **Prerequisite** — must merge before openshift/release#82053 |
| `release-4.18` | openshift/nmstate-console-plugin#268 | **Prerequisite** — must merge before openshift/release#82053 |
| `release-4.17` | openshift/nmstate-console-plugin#269 | **Prerequisite** — must merge before openshift/release#82053 |

## Test plan

- [ ] `npm run cypress` launches Cypress under Electron locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)