### PR TITLE
fix: use electron browser in cypress [release-4.20]

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "serve-build": "yarn build && npx http-server -p 9001 dist",
     "dev": "yarn webpack serve",
     "start-console": "./start-console.sh",
-    "cypress": "cypress run --browser chrome",
+    "cypress": "cypress run --browser electron",
     "cypress:open": "cypress open",
     "i18n": "i18next \"src/**/*.{js,jsx,ts,tsx}\" [-oc] -c i18next-parser.config.mjs",
     "lint": "eslint .",


### PR DESCRIPTION
## Summary

- Change `cypress run --browser chrome` → `cypress run --browser electron` in `package.json`

## Why this is a prerequisite

On `release-4.20`, `test-prow-e2e.sh` calls `yarn run cypress`, which maps to the `cypress` npm script. CI currently works because this branch still uses `tectonic-console-builder-v24`, which ships Chrome.

However, openshift/release#82053 will bump this branch to `tectonic-console-builder-v29` (which does **not** ship Chrome). **This PR must merge before openshift/release#82053** — otherwise CI on `release-4.20` will fail with the same error already seen on `release-4.19`:

```
Browser: chrome was not found on your system or is not supported by Cypress.
Available browsers found on your system are:
 - electron
```

## Background

`release-4.19` is currently broken because it was accidentally bumped to `v29` by openshift/release#78488 (a networking-console-plugin migration that inadvertently touched nmstate CI config). openshift/release#82053 standardizes all remaining branches to `v29` intentionally. This fix ensures `release-4.20` is ready.

## Companion PRs

**CI builder standardization** (openshift/release): openshift/release#82053

**This series** (all branches):
| Branch | PR | Role |
|---|---|---|
| `release-4.19` | openshift/nmstate-console-plugin#263 | **Urgent** — fixes active CI failure |
| `release-4.21` | openshift/nmstate-console-plugin#264 | Consistency — CI already uses electron |
| `release-4.22` | openshift/nmstate-console-plugin#265 | Consistency — CI already uses electron |
| `main` | openshift/nmstate-console-plugin#266 | Consistency — CI already uses electron |
| `release-4.20` | openshift/nmstate-console-plugin#267 | **Prerequisite** — must merge before openshift/release#82053 |
| `release-4.18` | openshift/nmstate-console-plugin#268 | **Prerequisite** — must merge before openshift/release#82053 |
| `release-4.17` | openshift/nmstate-console-plugin#269 | **Prerequisite** — must merge before openshift/release#82053 |

## Test plan

- [ ] CI on `release-4.20` continues to pass after openshift/release#82053 merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)