### PR TITLE
OCPBUGS-83807: Fix issues in NodeNetworkConfiguration topology view

### DIFF
--- a/cypress/e2e/NewPolicy.spec.cy.ts
+++ b/cypress/e2e/NewPolicy.spec.cy.ts
@@ -49,7 +49,8 @@ describe('Create new policy with form', () => {
     cy.byLegacyTestID('review-network-description').should('have.text', testDescription);
     cy.contains('button', 'Create network').click();
 
-    cy.contains('h1', testPolicyName);
+    cy.visit('/k8s/cluster/nmstate.io~v1~NodeNetworkConfigurationPolicy');
+    cy.contains('a', testPolicyName).should('be.visible').click();
 
     deletePolicyFromDetailsPage(testPolicyName);
   });

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -10,3 +10,5 @@ export const NO_DATA_DASH = '-';
 export const NMSTATE_I18N_NS = 'plugin__nmstate-console-plugin';
 
 export const FORBIDDEN_STATUS = 403;
+export const LINK_AGGREGATION = 'link-aggregation';
+export const BASE_IFACE = 'base-iface';

--- a/src/utils/topology/utils/constants.ts
+++ b/src/utils/topology/utils/constants.ts
@@ -7,3 +7,7 @@ export const GROUP = 'group';
 export const TOPOLOGY_LOCAL_STORAGE_KEY = 'topologyNodePositions';
 export const NODE_POSITIONING_EVENT = 'node-positioned';
 export const GRAPH_POSITIONING_EVENT = 'graph-position-change';
+
+export const OVN_K8S_MP0 = 'ovn-k8s-mp0';
+export const BR_INT = 'br-int';
+export const GENEV_SYS_PREFIX = 'genev_sys_';

--- a/src/utils/topology/utils/utils.ts
+++ b/src/utils/topology/utils/utils.ts
@@ -14,11 +14,12 @@ import {
   NodeShape,
   NodeStatus,
 } from '@patternfly/react-topology';
+import { BASE_IFACE, LINK_AGGREGATION } from '@utils/constants';
 import { isEmpty } from '@utils/helpers';
 
 import BridgeIcon from '../components/BridgeIcon';
 
-import { GROUP, NODE_DIAMETER } from './constants';
+import { BR_INT, GENEV_SYS_PREFIX, GROUP, NODE_DIAMETER, OVN_K8S_MP0 } from './constants';
 
 const statusMap: { [key: string]: NodeStatus } = {
   up: NodeStatus.success,
@@ -27,10 +28,13 @@ const statusMap: { [key: string]: NodeStatus } = {
 };
 
 const networkTypeLevelMap = {
+  [InterfaceType.OVS_INTERFACE]: 1,
+  [InterfaceType.OVS_BRIDGE]: 2,
   [InterfaceType.LINUX_BRIDGE]: 2,
   [InterfaceType.VLAN]: 3,
   [InterfaceType.BOND]: 4,
   [InterfaceType.ETHERNET]: 5,
+  [InterfaceType.INFINIBAND]: 5,
 };
 
 export const networkNodeLevel = new Proxy(networkTypeLevelMap, {
@@ -58,25 +62,30 @@ const getIcon = (iface: NodeNetworkConfigurationInterface) => {
 const createNodes = (
   nnsName: string,
   interfaces: NodeNetworkConfigurationInterface[],
-  nnceConfigredInterfaces: NodeNetworkConfigurationInterface[],
+  nnceConfiguredInterfaces: NodeNetworkConfigurationInterface[],
 ): NodeModel[] =>
   interfaces.map((iface) => {
-    const isDerivedFromPolicy = findInterfaceByName(nnceConfigredInterfaces, iface.name);
+    const isDerivedFromPolicy = findInterfaceByName(nnceConfiguredInterfaces, iface.name);
     return {
       id: `${nnsName}~${iface.name}~${iface.type}`,
       type: ModelKind.node,
       label: iface.name,
       width: NODE_DIAMETER,
       height: NODE_DIAMETER,
-      visible: !iface.patch && iface.type !== InterfaceType.LOOPBACK,
+      visible:
+        !iface.patch &&
+        iface.type !== InterfaceType.LOOPBACK &&
+        iface.name !== OVN_K8S_MP0 &&
+        iface.name !== BR_INT &&
+        !iface.name.startsWith(GENEV_SYS_PREFIX),
       shape: isDerivedFromPolicy ? NodeShape.circle : NodeShape.rect,
       status: getStatus(iface),
       data: {
         icon: getIcon(iface),
         type: iface.type,
         bridgePorts: iface.bridge?.port,
-        bondPorts: iface['link-aggregation']?.port,
-        vlanBaseInterface: iface.vlan?.['base-iface'],
+        bondPorts: iface[LINK_AGGREGATION]?.port,
+        vlanBaseInterface: iface.vlan?.[BASE_IFACE],
         level: networkNodeLevel[iface.type],
         isDerivedFromPolicy,
       },

--- a/src/views/policies/list/components/CreatePolicyButtons.tsx
+++ b/src/views/policies/list/components/CreatePolicyButtons.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { FC, ReactNode } from 'react';
 import { useNavigate } from 'react-router';
 import NodeNetworkConfigurationPolicyModel, {
   NodeNetworkConfigurationPolicyModelRef,
@@ -10,7 +10,11 @@ import { useNMStateTranslation } from '@utils/hooks/useNMStateTranslation';
 import { NNCP_YAML_EDITOR_OPENED } from '@utils/telemetry/constants';
 import { logNMStateEvent } from '@utils/telemetry/telemetry';
 
-const CreatePolicyButtons: FC = ({ children }) => {
+type CreatePolicyButtonsProps = {
+  children: ReactNode;
+};
+
+const CreatePolicyButtons: FC<CreatePolicyButtonsProps> = ({ children }) => {
   const { t } = useNMStateTranslation();
   const navigate = useNavigate();
 


### PR DESCRIPTION
## Summary

This is a continuation of #220 (same change set), opened because the original author (@pcbailey) is currently out and the PR branch could not be updated for conflict resolution.

- Rebased onto current `main` and resolved the merge conflict in `src/utils/constants.ts` by keeping both `FORBIDDEN_STATUS` (from main) and `LINK_AGGREGATION` / `BASE_IFACE` (from the original PR)
- Topology utility path rename on main (`src/views/nodenetworkconfiguration/utils/` → `src/utils/topology/utils/`) was applied cleanly during rebase
- Fixed the Cypress cleanup flow called out in #220 review: navigate into the policy details page before calling `deletePolicyFromDetailsPage`

Original PR behavior unchanged:
- Position `ovs-interface` interfaces above `ovs-bridge` interfaces
- Position `infiniband` interfaces at the bottom-most level next to `ethernet` interfaces
- Position `ovs-bridge` interfaces on the same level as `linux-bridge` interfaces
- Hide `ovn-k8s-mp0`, interfaces starting with `genev_sys_`, and `br-int`

Jira: https://redhat.atlassian.net/browse/OCPBUGS-83807

Please close #220 in favor of this PR once CI is green.

## Test plan
- [ ] Topology view shows ovs-interface above ovs-bridge, ovs-bridge aligned with linux-bridge, infiniband with ethernet
- [ ] Hidden interfaces (`ovn-k8s-mp0`, `genev_sys_*`, `br-int`) do not appear in topology
- [ ] Create-policy Cypress e2e: after create, list shows the policy; delete from details page succeeds
- [ ] `/hold cancel` and retest on this PR if needed (original #220 was held after e2e retest exhaustion)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved network topology visualization by accurately displaying supported interface types and hiding internal system interfaces.
  * Enhanced topology details for VLAN and link-aggregation connections.

* **Tests**
  * Updated policy creation coverage to verify that newly created policies can be opened from the policy list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->