### PR TITLE
[release-4.21] OCPBUGS-104488, OCPBUGS-101803: CVE-2026-14257, CVE-2026-69152 Upgrade brace-expansion to 5.0.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6407,15 +6407,15 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "word-wrap": "^1.2.5"
   },
   "overrides": {
-    "brace-expansion": "5.0.7",
+    "brace-expansion": "5.0.9",
     "@parcel/watcher": "2.5.1",
     "lodash": "4.18.1",
     "immutable": {


### PR DESCRIPTION
Update brace-expansion to v5.0.9 per CVE-2026-14257 and CVE-2026-69152.

Jira tickets: 

- https://redhat.atlassian.net/browse/OCPBUGS-101803
- https://redhat.atlassian.net/browse/OCPBUGS-104488